### PR TITLE
SIP support for node-terminal launch type

### DIFF
--- a/changelog.d/26.added.md
+++ b/changelog.d/26.added.md
@@ -1,0 +1,1 @@
+Support for launch configuration with type `node-terminal`.

--- a/src/api.ts
+++ b/src/api.ts
@@ -102,7 +102,7 @@ export function mirrordFailure(error: string) {
 }
 
 // Like the Rust MirrordExecution struct.
-class MirrordExecution {
+export class MirrordExecution {
 
     env: Map<string, string>;
     patchedPath: string | null;
@@ -114,7 +114,7 @@ class MirrordExecution {
 
     static mirrordExecutionFromJson(data: string): MirrordExecution {
         const parsed = JSON.parse(data);
-        return new MirrordExecution(parsed["environment"], parsed["patched_path"]);
+        return new MirrordExecution(new Map(Object.entries(parsed["environment"])), parsed["patched_path"]);
     }
 
 }

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -57,10 +57,8 @@ function changeConfigForSip(config: vscode.DebugConfiguration, executableFieldNa
 		// which is SIP protected, so our DYLD env var is silently removed. So in order to bypass
 		// that, we set that variable in the command line.
 		config[executableFieldName] = `${DYLD_ENV_VAR_NAME}=${libraryPath} ${command}`;
-	} else {
-		if (executionInfo.patchedPath !== null) {
-			config[executableFieldName] = executionInfo.patchedPath!;
-		}
+	} else if (executionInfo.patchedPath !== null) {
+		config[executableFieldName] = executionInfo.patchedPath!;
 	}
 }
 

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -17,6 +17,7 @@ function getFieldAndExecutable(config: vscode.DebugConfiguration): [keyof vscode
 	switch (config.type) {
 		case "pwa-node":
 		case "node": {
+			// https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_launch-configuration-attributes
 			return ["runtimeExecutable", config["runtimeExecutable"]];
 		}
 		case "node-terminal": {

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -9,7 +9,10 @@ import { platform } from 'node:os';
 
 const DYLD_ENV_VAR_NAME = "DYLD_INSERT_LIBRARIES";
 
-/// Get the name of the field that holds the exectuable in a debug configuration of the given type.
+/// Get the name of the field that holds the exectuable in a debug configuration of the given type,
+/// and the executable. Returning the field name for replacing the value with the patched path later.
+/// Also returning the executable because in some configuration types there is some extra logic to
+/// be done for retrieving the executable out of its field (see the `node-terminal` case).
 function getFieldAndExecutable(config: vscode.DebugConfiguration): [keyof vscode.DebugConfiguration, string | null] {
 	switch (config.type) {
 		case "pwa-node":
@@ -33,6 +36,9 @@ function getFieldAndExecutable(config: vscode.DebugConfiguration): [keyof vscode
 	}
 }
 
+/// Edit the launch configuration in order to sidestep SIP on macOS, and allow the layer to be
+/// loaded into the process. This includes replacing the executable with the path to a patched
+/// executable if the original executable is SIP protected, and some other special workarounds.
 function changeConfigForSip(config: vscode.DebugConfiguration, executableFieldName: string, executionInfo: MirrordExecution) {
 	if (config.type === "node-terminal") {
 		let command = config[executableFieldName];

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -28,7 +28,7 @@ function getFieldAndExecutable(config: vscode.DebugConfiguration): [keyof vscode
 			}
 			// Official documentation states the relevant field name is "python" (https://code.visualstudio.com/docs/python/debugging#_python), 
 			// but when debugging we see the field is called "pythonPath".
-			return ["pythonPath", config["python"]];
+			return ["pythonPath", config["pythonPath"]];
 		}
 		default: {
 			return ["program", config["program"]];


### PR DESCRIPTION
Closes #26 

The way we sidestep SIP on vscode is to get the executable from the launch configuration - pass it to the mirrord CLI, and replace the executable in the config with a path to the patched executable.
Since each configuration type puts the executable in a different configuration field, we need to individually add support for each configuration type.

With this new type, `node-terminal`, it's a tiny bit more complicated then in all other cases so far, because there is no field that holds just the executable. There is a `command` field, that holds a command line that is probably passed as an argument to `sh`/`bash`/whatever. This leads to 2 slight complications:
1. We don't just replace the whole field, we need to replace just the executable out of the line.
2. Since vscode calls something like `sh -c <command>`, and there is no field in the configuration that controls that `sh`/`bash`/whatever, we cannot replace it with a patched binary. Since bash is SIP, `DYLD_INSERT_LIBRARIES` is silently stripped away from the env. So to get around that challenge, we prepend that env var to the command line, and then the layer is loaded to the potentially SIP-patched binary.

This means that if the user sets the `command` field of the launch configuration to be `"npm run dotenv-cli"`, we change it to something like `DYLD_INSERT_LIBRARIES=/tmp/14438233328252234237-libmirrord_layer.dylib /var/folders/4l/810mmn597cx7zy5w2bk11clh0000gn/T/mirrord-bin/opt/homebrew/bin/npm run dotenv-cli`.