### PR TITLE
wrap node-terminal command with shell

### DIFF
--- a/changelog.d/34.fixed.md
+++ b/changelog.d/34.fixed.md
@@ -1,0 +1,1 @@
+Support multi-command "node-terminal" commands.

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -49,7 +49,7 @@ function changeConfigForSip(config: vscode.DebugConfiguration, executableFieldNa
 		if (command === null) {
 			return;
 		}
-		const escapedCommand = command.replaceAll('"', '\\"');
+		const escapedCommand = command.replaceAll("'", "'\\''");
 		const sh = executionInfo.patchedPath ?? vscode.env.shell;
 
 		const libraryPath = executionInfo.env.get(DYLD_ENV_VAR_NAME);
@@ -57,7 +57,7 @@ function changeConfigForSip(config: vscode.DebugConfiguration, executableFieldNa
 		// vscode passes the command to something like `sh`, which we cannot patch or change, and
 		// which is SIP protected, so our DYLD env var is silently removed. So in order to bypass
 		// that, we set that variable in the command line.
-		config[executableFieldName] = `echo "${escapedCommand}" | ${DYLD_ENV_VAR_NAME}=${libraryPath} ${sh} -is`;
+		config[executableFieldName] = `echo '${escapedCommand}' | ${DYLD_ENV_VAR_NAME}=${libraryPath} ${sh} -is`;
 	} else if (executionInfo.patchedPath !== null) {
 		config[executableFieldName] = executionInfo.patchedPath!;
 	}

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -42,18 +42,19 @@ function getFieldAndExecutable(config: vscode.DebugConfiguration): [keyof vscode
 /// executable if the original executable is SIP protected, and some other special workarounds.
 function changeConfigForSip(config: vscode.DebugConfiguration, executableFieldName: string, executionInfo: MirrordExecution) {
 	if (config.type === "node-terminal") {
-		let command = config[executableFieldName];
+		const command = config[executableFieldName];
 		if (command === null) {
 			return;
 		}
+		const escapedCommand = command.replaceAll('"', '\\"');
 		const sh = executionInfo.patchedPath ?? "zsh";
 
-		let libraryPath = executionInfo.env.get(DYLD_ENV_VAR_NAME);
+		const libraryPath = executionInfo.env.get(DYLD_ENV_VAR_NAME);
 
 		// vscode passes the command to something like `sh`, which we cannot patch or change, and
 		// which is SIP protected, so our DYLD env var is silently removed. So in order to bypass
 		// that, we set that variable in the command line.
-		config[executableFieldName] = `echo "${command}" | ${DYLD_ENV_VAR_NAME}=${libraryPath} ${sh} -is`;
+		config[executableFieldName] = `echo "${escapedCommand}" | ${DYLD_ENV_VAR_NAME}=${libraryPath} ${sh} -is`;
 	} else if (executionInfo.patchedPath !== null) {
 		config[executableFieldName] = executionInfo.patchedPath!;
 	}

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -49,6 +49,9 @@ function changeConfigForSip(config: vscode.DebugConfiguration, executableFieldNa
 		if (command === null) {
 			return;
 		}
+
+		// The command could have single quotes, and we are putting the whole command in single quotes in the changed command.
+		// So we replace each `'` with `'\''` (closes the string, concats an escaped single quote, opens the string)
 		const escapedCommand = command.replaceAll("'", "'\\''");
 		const sh = executionInfo.patchedPath ?? vscode.env.shell;
 

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -21,7 +21,7 @@ function getFieldAndExecutable(config: vscode.DebugConfiguration): [keyof vscode
 			return ["runtimeExecutable", config["runtimeExecutable"]];
 		}
 		case "node-terminal": {
-			return ["command", "zsh"];
+			return ["command", vscode.env.shell];
 		}
 		case "python": {
 			if ("python" in config) {
@@ -47,7 +47,7 @@ function changeConfigForSip(config: vscode.DebugConfiguration, executableFieldNa
 			return;
 		}
 		const escapedCommand = command.replaceAll('"', '\\"');
-		const sh = executionInfo.patchedPath ?? "zsh";
+		const sh = executionInfo.patchedPath ?? vscode.env.shell;
 
 		const libraryPath = executionInfo.env.get(DYLD_ENV_VAR_NAME);
 

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -21,7 +21,7 @@ function getFieldAndExecutable(config: vscode.DebugConfiguration): [keyof vscode
 			return ["runtimeExecutable", config["runtimeExecutable"]];
 		}
 		case "node-terminal": {
-			return ["command", config["command"]?.split(' ')[0]];
+			return ["command", "sh"];
 		}
 		case "python": {
 			if ("python" in config) {
@@ -46,18 +46,14 @@ function changeConfigForSip(config: vscode.DebugConfiguration, executableFieldNa
 		if (command === null) {
 			return;
 		}
-		if (executionInfo.patchedPath !== null) {
-			// replace the first word of the command line with a patched version of the executable.
-			let words = command.split(' ');
-			words[0] = executionInfo.patchedPath;
-			command = words.join(' ');
-		}
+		const sh = executionInfo.patchedPath ?? "sh";
+
 		let libraryPath = executionInfo.env.get(DYLD_ENV_VAR_NAME);
 
 		// vscode passes the command to something like `sh`, which we cannot patch or change, and
 		// which is SIP protected, so our DYLD env var is silently removed. So in order to bypass
 		// that, we set that variable in the command line.
-		config[executableFieldName] = `${DYLD_ENV_VAR_NAME}=${libraryPath} ${command}`;
+		config[executableFieldName] = `${DYLD_ENV_VAR_NAME}=${libraryPath} ${sh} --login -c "${command}"`;
 	} else if (executionInfo.patchedPath !== null) {
 		config[executableFieldName] = executionInfo.patchedPath!;
 	}

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -57,9 +57,8 @@ function changeConfigForSip(config: vscode.DebugConfiguration, executableFieldNa
 
 		const libraryPath = executionInfo.env.get(DYLD_ENV_VAR_NAME);
 
-		// vscode passes the command to something like `sh`, which we cannot patch or change, and
-		// which is SIP protected, so our DYLD env var is silently removed. So in order to bypass
-		// that, we set that variable in the command line.
+		// Run the command in a SIP-patched shell, that way everything that runs in the original command will be SIP-patched
+		// on runtime.
 		config[executableFieldName] = `echo '${escapedCommand}' | ${DYLD_ENV_VAR_NAME}=${libraryPath} ${sh} -is`;
 	} else if (executionInfo.patchedPath !== null) {
 		config[executableFieldName] = executionInfo.patchedPath!;

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -21,6 +21,9 @@ function getFieldAndExecutable(config: vscode.DebugConfiguration): [keyof vscode
 			return ["runtimeExecutable", config["runtimeExecutable"]];
 		}
 		case "node-terminal": {
+			// Command could contain multiple commands like "command1 arg1; command2 arg2", so we execute that command
+			// in a shell, to which we inject the layer. In order to inject the layer to the shell, we have to patch it
+			// for SIP, so we pass the shell to the mirrod CLI.
 			return ["command", vscode.env.shell];
 		}
 		case "python": {

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -21,7 +21,7 @@ function getFieldAndExecutable(config: vscode.DebugConfiguration): [keyof vscode
 			return ["runtimeExecutable", config["runtimeExecutable"]];
 		}
 		case "node-terminal": {
-			return ["command", "sh"];
+			return ["command", "zsh"];
 		}
 		case "python": {
 			if ("python" in config) {
@@ -46,14 +46,14 @@ function changeConfigForSip(config: vscode.DebugConfiguration, executableFieldNa
 		if (command === null) {
 			return;
 		}
-		const sh = executionInfo.patchedPath ?? "sh";
+		const sh = executionInfo.patchedPath ?? "zsh";
 
 		let libraryPath = executionInfo.env.get(DYLD_ENV_VAR_NAME);
 
 		// vscode passes the command to something like `sh`, which we cannot patch or change, and
 		// which is SIP protected, so our DYLD env var is silently removed. So in order to bypass
 		// that, we set that variable in the command line.
-		config[executableFieldName] = `${DYLD_ENV_VAR_NAME}=${libraryPath} ${sh} --login -c "${command}"`;
+		config[executableFieldName] = `echo "${command}" | ${DYLD_ENV_VAR_NAME}=${libraryPath} ${sh} -is`;
 	} else if (executionInfo.patchedPath !== null) {
 		config[executableFieldName] = executionInfo.patchedPath!;
 	}


### PR DESCRIPTION
Fixes #34 

Current problem: when wrapping the command with a non-interactive shell `~/.zshrc` is not executed, so nvm is not found.