### PR TITLE
Config relative path

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ mirrord allows for rich configuration of the environment it provides. The schema
 mirrord reads its configuration from the following locations:
 
 1. Active config can be set for the whole workspace using the `selectActiveConfig` command or the link in the dropdown menu. If active config is set, mirrord always uses it.
-2. If active config is not set, mirrord searches process environment (specified in launch configuration) for `MIRRORD_CONFIG_FILE` variable. This can be an absolute path or path relative to the project root.
+2. If active config is not set, mirrord searches process environment (specified in launch configuration) for `MIRRORD_CONFIG_FILE` variable. This path can use the `${workspaceFolder}` variable.
 3. If no config is specified, mirrord looks for a default project config file in the `.mirrord` directory with a name ending with `mirrord.{json,toml,yaml,yml}`. If there is no default config file, mirrord uses default configuration values for everything. If there are many candidates for the default config file, mirrord sorts them alphabetically and uses the first one.
 
 You can use the `changeSettings` command or the link in the dropdown menu to quickly edit detected configs.

--- a/changelog.d/30.added.md
+++ b/changelog.d/30.added.md
@@ -1,0 +1,1 @@
+Path to the mirrord config specified in launch configuration can now use the `workspaceFolder` variable.

--- a/media/walkthrough/configuration.md
+++ b/media/walkthrough/configuration.md
@@ -34,12 +34,32 @@ You can specify configuration file to use for specific the launch configuration.
             "console": "integratedTerminal",
             "justMyCode": true,
             "env": {
-                "MIRRORD_CONFIG_FILE": ".mirrord/sample_mirrord.json"
+                "MIRRORD_CONFIG_FILE": "/path/to/workspace/.mirrord/sample_mirrord.json"
             }
         }
     ]
 }
+```
 
+You can also use the `workspaceFolder` variable:
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "env": {
+                "MIRRORD_CONFIG_FILE": "${workspaceFolder}/.mirrord/sample_mirrord.json"
+            }
+        }
+    ]
+}
 ```
 
 # Active config feature

--- a/src/config.ts
+++ b/src/config.ts
@@ -234,6 +234,20 @@ export class MirrordConfigManager {
     }
 
     /**
+     * Resolves config file path specified in the launch config.
+     * @param folder workspace folder of the launch config
+     * @param path taken from the `MIRRORD_CONFIG_FILE` environment variable in launch config
+     * @returns config file Uri
+     */
+    private static processPathFromLaunchConfig(folder: vscode.WorkspaceFolder | undefined, path: string): vscode.Uri {
+        if (folder) {
+            path = path.replace(/\$\{workspaceFolder\}/g, folder.uri.fsPath);
+        }
+
+        return vscode.Uri.file(path);
+    }
+
+    /**
      * Used when preparing mirrord environment for the process.
      * @param folder optional origin of the launch config
      * @param config debug configuration used
@@ -250,8 +264,8 @@ export class MirrordConfigManager {
         }
 
         let launchConfig = config.env?.["MIRRORD_CONFIG_FILE"];
-        if (launchConfig) {
-            return vscode.Uri.file(launchConfig);
+        if (typeof launchConfig === "string") {
+            return MirrordConfigManager.processPathFromLaunchConfig(folder, launchConfig);
         }
 
         if (folder) {


### PR DESCRIPTION
Closes #30 

Looks like VS Code API does not have functions for resolving the variables (there are more than `workspaceFolder`). Found a [package](https://www.npmjs.com/package/vscode-variables) that does it, but it introduces vulnerabilities