### PR TITLE
Use mirrord verify-config to validate the user config.

### DIFF
--- a/changelog.d/57.added.md
+++ b/changelog.d/57.added.md
@@ -1,0 +1,1 @@
+Use mirrord verify-config to validate a config file before proceeding with mirrord execution.

--- a/src/api.ts
+++ b/src/api.ts
@@ -4,6 +4,7 @@ import { globalContext } from './extension';
 import { tickWaitlistCounter } from './waitlist';
 import { NotificationBuilder } from './notification';
 import { MirrordStatus } from './status';
+import { VerifiedConfig } from './config';
 
 /**
 * Key to access the feedback counter (see `tickFeedbackCounter`) from the global user config.
@@ -132,7 +133,9 @@ export class MirrordExecution {
 
 }
 
-// API to interact with the mirrord CLI, runs in the "ext" mode
+/**
+* API to interact with the mirrord CLI, runs in the "ext" mode.
+*/
 export class MirrordAPI {
   cliPath: string;
 
@@ -194,8 +197,10 @@ export class MirrordAPI {
     });
   }
 
-  // Spawn the mirrord cli with the given arguments
-  // used for reading/interacting while process still runs.
+  /** 
+  * Spawn the mirrord cli with the given arguments.
+  * Used for reading/interacting while process still runs.
+  */
   private spawn(args: string[]): ChildProcessWithoutNullStreams {
     return spawn(this.cliPath, args, { env: MirrordAPI.getEnv() });
   }
@@ -209,8 +214,10 @@ export class MirrordAPI {
     return stdout.split(" ")[1].trim();
   }
 
-  /// Uses `mirrord ls` to get a list of all targets.
-  /// Targets are sorted, with an exception of the last used target being the first on the list.
+  /**
+  * Uses `mirrord ls` to get a list of all targets.
+  * Targets are sorted, with an exception of the last used target being the first on the list.
+  */
   async listTargets(configPath: string | null | undefined): Promise<Targets> {
     const args = ['ls'];
     if (configPath) {
@@ -234,6 +241,19 @@ export class MirrordAPI {
     }
 
     return new Targets(targets, lastTarget);
+  }
+
+  // TODO(alex): This is how we execute `mirrord verify-config {path}`
+  async verifyConfig(configPath: vscode.Uri | null): Promise<VerifiedConfig | undefined> {
+    const args = ['verify-config'];
+    if (configPath) {
+      args.push('${configPath}');
+      const stdout = await this.exec(args);
+      const verifiedConfig: VerifiedConfig = JSON.parse(stdout);
+      return verifiedConfig;
+    } else {
+      return undefined;
+    }
   }
 
   // Run the extension execute sequence

--- a/src/api.ts
+++ b/src/api.ts
@@ -243,12 +243,16 @@ export class MirrordAPI {
     return new Targets(targets, lastTarget);
   }
 
-  // TODO(alex): This is how we execute `mirrord verify-config {path}`
+  /**
+  * Executes the `mirrord verify-config {configPath}` command, parsing its output into a
+  * `VerifiedConfig`.
+  */
   async verifyConfig(configPath: vscode.Uri | null): Promise<VerifiedConfig | undefined> {
     const args = ['verify-config'];
     if (configPath) {
-      args.push('${configPath}');
+      args.push(configPath.path);
       const stdout = await this.exec(args);
+
       const verifiedConfig: VerifiedConfig = JSON.parse(stdout);
       return verifiedConfig;
     } else {

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,12 +31,12 @@ export type VerifiedConfig = ConfigSuccess | ConfigFail;
 /**
 * When `mirrord verify-config` results in a `"Success"`.
 */
-type ConfigSuccess = { 'type': 'Success', config: Config, warnings: string[] }
+type ConfigSuccess = { 'type': 'Success', config: Config, warnings: string[] };
 
 /**
 * When `mirrord verify-config` results in a `"Fail"`.
 */
-type ConfigFail = { 'type': 'Fail', errors: string[] }
+type ConfigFail = { 'type': 'Fail', errors: string[] };
 
 
 /**
@@ -63,10 +63,10 @@ export interface Path {
 export function isTargetSet(verifiedConfig: VerifiedConfig): boolean {
   switch (verifiedConfig.type) {
     case 'Success':
-      verifiedConfig.warnings.forEach((warn) => new NotificationBuilder().withMessage(warn).warning())
+      verifiedConfig.warnings.forEach((warn) => new NotificationBuilder().withMessage(warn).warning());
       return verifiedConfig.config.path !== undefined;
     case 'Fail':
-      verifiedConfig.errors.forEach((fail) => new NotificationBuilder().withMessage(fail).error())
+      verifiedConfig.errors.forEach((fail) => new NotificationBuilder().withMessage(fail).error());
       return false;
     default:
       let _guard: never = verifiedConfig;

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import YAML from 'yaml';
 import TOML from 'toml';
 import { NotificationBuilder } from './notification';
+import { mirrordFailure } from './api';
 
 /**
  * Default mirrord configuration.
@@ -59,6 +60,10 @@ export interface Path {
 * Looks into the `verifiedConfig` to see if it has a `Target` set (by checking `Config.path`).
 *
 * Also displays warnings/errors if there are any.
+*
+* When `Fail` is detected, we throw an exception after displaying the errors to the user to stop
+* execution, if you `try/catch` this function call, normal mirrord execution will continue until it
+* hits the normal mirrord-config handler.
 */
 export function isTargetSet(verifiedConfig: VerifiedConfig): boolean {
   switch (verifiedConfig.type) {
@@ -67,12 +72,11 @@ export function isTargetSet(verifiedConfig: VerifiedConfig): boolean {
       return verifiedConfig.config.path !== undefined;
     case 'Fail':
       verifiedConfig.errors.forEach((fail) => new NotificationBuilder().withMessage(fail).error());
-      return false;
+      throw new Error('mirrord verify-config detected an invalid configuration!');
     default:
       let _guard: never = verifiedConfig;
       return _guard;
   }
-
 }
 
 export class MirrordConfigManager {

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,298 +19,326 @@ const DEFAULT_CONFIG = `{
 `;
 
 interface LaunchConfig {
-    name: string,
-    env?: { [key: string]: string};
+  name: string,
+  env?: { [key: string]: string };
+}
+
+export type VerifiedConfig = ConfigSuccess | ConfigFail;
+type ConfigSuccess = { 'type': 'Success', config: Config, warnings: string[] }
+type ConfigFail = { 'type': 'Fail', errors: string[] }
+
+export interface Config {
+  path: Path | undefined
+  namespace: string | undefined
+}
+
+export interface Path {
+  deployment: string | undefined
+  container: string | undefined
+}
+
+export function isTargetSet(verifiedConfig: VerifiedConfig): boolean {
+  switch (verifiedConfig.type) {
+    case 'Success':
+      verifiedConfig.warnings.forEach((warn) => new NotificationBuilder().withMessage(warn).warning())
+      return verifiedConfig.config.path !== undefined;
+    case 'Fail':
+      verifiedConfig.errors.forEach((fail) => new NotificationBuilder().withMessage(fail).error())
+      return false;
+    default:
+      throw undefined;
+  }
+
 }
 
 export class MirrordConfigManager {
-    private static instance?: MirrordConfigManager = undefined;
+  private static instance?: MirrordConfigManager = undefined;
 
-    /**
-     * Active config. User can set this for the whole workspace.
-     */
-    private active?: vscode.Uri;
-    private fileListeners: vscode.Disposable[];
-    /**
-     * All will be called when the active config changes.
-     */
-    private activeConfigListeners: ((active?: vscode.Uri) => Thenable<any>)[];
+  /**
+   * Active config. User can set this for the whole workspace.
+   */
+  private active?: vscode.Uri;
+  private fileListeners: vscode.Disposable[];
+  /**
+   * All will be called when the active config changes.
+   */
+  private activeConfigListeners: ((active?: vscode.Uri) => Thenable<any>)[];
 
-    private constructor() {
-        this.fileListeners = [];
+  private constructor() {
+    this.fileListeners = [];
 
-        this.fileListeners.push(vscode.workspace.onDidDeleteFiles(async event => {
-            const activePath = this.active?.path;
-            if (!activePath) {
-                return;
-            }
+    this.fileListeners.push(vscode.workspace.onDidDeleteFiles(async event => {
+      const activePath = this.active?.path;
+      if (!activePath) {
+        return;
+      }
 
-            const deleted = event.files.find(file => activePath.startsWith(file.path));
+      const deleted = event.files.find(file => activePath.startsWith(file.path));
 
-            if (deleted) {
-                new NotificationBuilder()
-                    .withMessage("removed active mirrord configuration")
-                    .withDisableAction("promptActiveConfigRemoved")
-                    .warning();
+      if (deleted) {
+        new NotificationBuilder()
+          .withMessage("removed active mirrord configuration")
+          .withDisableAction("promptActiveConfigRemoved")
+          .warning();
 
-                this.setActiveConfig(undefined);
+        this.setActiveConfig(undefined);
 
-                return;
-            }
-        }));
+        return;
+      }
+    }));
 
-        this.fileListeners.push(vscode.workspace.onDidRenameFiles(async event => {
-            const activePath = this.active?.path;
-            if (!activePath) {
-                return;
-            }
+    this.fileListeners.push(vscode.workspace.onDidRenameFiles(async event => {
+      const activePath = this.active?.path;
+      if (!activePath) {
+        return;
+      }
 
-            const moved = event.files.find(file => activePath.startsWith(file.oldUri.path));
-            if (moved) {
-                const newPath = activePath.replace(moved.oldUri.path, moved.newUri.path);
-                const newUri = vscode.Uri.parse(`file://${newPath}`);
-                new NotificationBuilder()
-                    .withMessage(`moved active mirrord configuration to ${vscode.workspace.asRelativePath(newUri)}`)
-                    .withDisableAction("promptActiveConfigMoved")
-                    .warning();
+      const moved = event.files.find(file => activePath.startsWith(file.oldUri.path));
+      if (moved) {
+        const newPath = activePath.replace(moved.oldUri.path, moved.newUri.path);
+        const newUri = vscode.Uri.parse(`file://${newPath}`);
+        new NotificationBuilder()
+          .withMessage(`moved active mirrord configuration to ${vscode.workspace.asRelativePath(newUri)}`)
+          .withDisableAction("promptActiveConfigMoved")
+          .warning();
 
-                this.setActiveConfig(newUri);
+        this.setActiveConfig(newUri);
 
-                return;
-            }
-        }));
+        return;
+      }
+    }));
 
-        this.activeConfigListeners = [];
+    this.activeConfigListeners = [];
+  }
+
+  private setActiveConfig(newConfig?: vscode.Uri) {
+    this.active = newConfig;
+    this.activeConfigListeners.forEach(l => l(newConfig));
+  }
+
+  public dispose() {
+    this.fileListeners.forEach(fl => fl.dispose());
+  }
+
+  public onActiveConfigChange(listener: (active?: vscode.Uri) => Thenable<any>) {
+    this.activeConfigListeners.push(listener);
+  }
+
+  /**
+   * @returns a global instance of this manager
+   */
+  public static getInstance(): MirrordConfigManager {
+    if (MirrordConfigManager.instance === undefined) {
+      MirrordConfigManager.instance = new MirrordConfigManager();
     }
 
-    private setActiveConfig(newConfig?: vscode.Uri) {
-        this.active = newConfig;
-        this.activeConfigListeners.forEach(l => l(newConfig));
+    return MirrordConfigManager.instance;
+  }
+
+  public activeConfig(): vscode.Uri | undefined {
+    return this.active;
+  }
+
+  /**
+   * Handles `mirrord.selectActiveConfig` command.
+   * Allows the user to set an active mirrord config from quick pick.
+   * Any path across the workspace is available, as long as its name ends with `mirrord.{json,toml,yml,yaml}`.
+   */
+  public async selectActiveConfig() {
+    const options: Map<string, vscode.Uri> = new Map();
+    const files = await vscode.workspace.findFiles("**/*mirrord.{json,toml,yml,yaml}");
+    files.forEach(f => options.set(vscode.workspace.asRelativePath(f), f));
+
+    const displayed = this.active ? ["<unset active config>", ...options.keys()] : [...options.keys()];
+    const placeHolder = this.active
+      ? `Select active mirrord config from the workspace (currently ${vscode.workspace.asRelativePath(this.active)})`
+      : "Select active mirrord config from the workspace";
+    const selected = await vscode.window.showQuickPick(displayed, { placeHolder });
+    if (selected === "<unset active config>") {
+      this.setActiveConfig(undefined);
+    } else if (selected) {
+      let path = options.get(selected)!!;
+      this.setActiveConfig(path);
+    }
+  }
+
+  /**
+   * Searches the given workspace folder for a default config.
+   * Default configs are located in the `.mirrord` directory and their names end with `mirrord.{toml,json,yml,yaml}`.
+   * If there are multiple candidates, they are sorted according alphabetically and the first one is returned.
+   * @param folder searched workspace folder
+   * @returns path to the found config
+   */
+  private static async getDefaultConfig(folder: vscode.WorkspaceFolder): Promise<vscode.Uri | undefined> {
+    let pattern = new vscode.RelativePattern(folder, ".mirrord/*mirrord.{toml,json,yml,yaml}");
+    let files = await vscode.workspace.findFiles(pattern);
+    files.sort((f1, f2) => f1.path.localeCompare(f2.path));
+    return files[0];
+  }
+
+  /**
+   * Creates a default config in the given workspace folder.
+   * The config is created under `.mirrord/mirrord.json`.
+   * @param folder workspace folder for the config
+   * @returns path to the created config
+   */
+  private static async createDefaultConfig(folder: vscode.WorkspaceFolder): Promise<vscode.Uri> {
+    let path = vscode.Uri.joinPath(folder.uri, ".mirrord", "mirrord.json");
+    await vscode.workspace.fs.writeFile(path, Buffer.from(DEFAULT_CONFIG));
+    return path;
+  }
+
+  /**
+   * Handles `mirrord.changeSettings` command.
+   * Allows the user to open a mirrord config file selected from quick pick.
+   * Quick pick options in order:
+   *  - active config (if set)
+   *  - configs used in launch configurations across the workspace
+   *  - default configs across the workspace
+   */
+  public async changeSettings() {
+    const options: Map<string, vscode.Uri> = new Map();
+
+    // Active config first.
+    if (this.active) {
+      options.set(`(active) ${vscode.workspace.asRelativePath(this.active.path)}`, this.active);
     }
 
-    public dispose() {
-        this.fileListeners.forEach(fl => fl.dispose());
+    // Then all configs found in launch configurations across the workspace.
+    const folders = vscode.workspace.workspaceFolders || [];
+    for (const folder of folders) {
+      let launchConfigs = vscode.workspace.getConfiguration("launch", folder)?.get<LaunchConfig[]>("configurations") || [];
+      for (const launchConfig of launchConfigs) {
+        let rawPath = launchConfig.env?.["MIRRORD_CONFIG_FILE"];
+        if (!rawPath) {
+          continue;
+        }
+
+        let path;
+        if (rawPath.startsWith("/")) {
+          path = vscode.Uri.file(rawPath);
+        } else {
+          path = vscode.Uri.joinPath(folder.uri, rawPath);
+
+        }
+
+        if (folders.length > 1) {
+          options.set(`(launch config ${folder.name}:${launchConfig.name}) ${vscode.workspace.asRelativePath(path)}`, path);
+        } else {
+          options.set(`(launch config ${launchConfig.name}) ${vscode.workspace.asRelativePath(path)}`, path);
+        }
+      }
     }
 
-    public onActiveConfigChange(listener: (active?: vscode.Uri) => Thenable<any>) {
-        this.activeConfigListeners.push(listener);
+    // Then all default configurations across the workspace.
+    for (const folder of folders) {
+      let path = await MirrordConfigManager.getDefaultConfig(folder);
+      if (path) {
+        options.set(`(default) ${vscode.workspace.asRelativePath(path)}`, path);
+      } else {
+        let path = vscode.Uri.joinPath(folder.uri, ".mirrord/mirrord.json");
+        options.set(`(create default) ${vscode.workspace.asRelativePath(path)}`, path);
+      }
     }
 
-    /**
-     * @returns a global instance of this manager
-     */
-    public static getInstance(): MirrordConfigManager {
-        if (MirrordConfigManager.instance === undefined) {
-            MirrordConfigManager.instance = new MirrordConfigManager();
-        }
+    let quickPickOptions = [...options.keys()];
+    let selected = quickPickOptions.length > 1
+      ? await vscode.window.showQuickPick(quickPickOptions, { placeHolder: "Select mirrord config to open" })
+      : quickPickOptions[0];
 
-        return MirrordConfigManager.instance;
+    if (!selected) {
+      return;
     }
 
-    public activeConfig(): vscode.Uri | undefined {
-        return this.active;
+    let path = options.get(selected)!!;
+    if (selected.startsWith("(create default)")) {
+      await MirrordConfigManager.createDefaultConfig(vscode.workspace.getWorkspaceFolder(path)!!);
     }
 
-    /**
-     * Handles `mirrord.selectActiveConfig` command.
-     * Allows the user to set an active mirrord config from quick pick.
-     * Any path across the workspace is available, as long as its name ends with `mirrord.{json,toml,yml,yaml}`.
-     */
-    public async selectActiveConfig() {
-        const options: Map<string, vscode.Uri> = new Map();
-        const files = await vscode.workspace.findFiles("**/*mirrord.{json,toml,yml,yaml}");
-        files.forEach(f => options.set(vscode.workspace.asRelativePath(f), f));
+    let doc = await vscode.workspace.openTextDocument(path.path);
+    vscode.window.showTextDocument(doc);
+  }
 
-        const displayed = this.active ? ["<unset active config>", ...options.keys()] : [...options.keys()];
-        const placeHolder = this.active
-            ? `Select active mirrord config from the workspace (currently ${vscode.workspace.asRelativePath(this.active)})`
-            : "Select active mirrord config from the workspace";
-        const selected = await vscode.window.showQuickPick(displayed, {placeHolder});
-        if (selected === "<unset active config>") {
-            this.setActiveConfig(undefined);
-        } else if (selected) {
-            let path = options.get(selected)!!;
-            this.setActiveConfig(path);
-        }
+  /**
+   * Resolves config file path specified in the launch config.
+   * @param folder workspace folder of the launch config
+   * @param path taken from the `MIRRORD_CONFIG_FILE` environment variable in launch config
+   * @returns config file Uri
+   */
+  private static processPathFromLaunchConfig(folder: vscode.WorkspaceFolder | undefined, path: string): vscode.Uri {
+    if (folder) {
+      path = path.replace(/\$\{workspaceFolder\}/g, folder.uri.fsPath);
     }
 
-    /**
-     * Searches the given workspace folder for a default config.
-     * Default configs are located in the `.mirrord` directory and their names end with `mirrord.{toml,json,yml,yaml}`.
-     * If there are multiple candidates, they are sorted according alphabetically and the first one is returned.
-     * @param folder searched workspace folder
-     * @returns path to the found config
-     */
-    private static async getDefaultConfig(folder: vscode.WorkspaceFolder): Promise<vscode.Uri | undefined> {
-        let pattern = new vscode.RelativePattern(folder, ".mirrord/*mirrord.{toml,json,yml,yaml}");
-        let files = await vscode.workspace.findFiles(pattern);
-        files.sort((f1, f2) => f1.path.localeCompare(f2.path));
-        return files[0];
+    return vscode.Uri.file(path);
+  }
+
+  /**
+   * Used when preparing mirrord environment for the process.
+   * @param folder optional origin of the launch config
+   * @param config debug configuration used
+   * @returns path to the mirrord config
+   */
+  public async resolveMirrordConfig(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration): Promise<vscode.Uri | null> {
+    if (this.active) {
+      new NotificationBuilder()
+        .withMessage("using active mirrord configuration")
+        .withOpenFileAction(this.active)
+        .withDisableAction("promptUsingActiveConfig")
+        .info();
+      return this.active;
     }
 
-    /**
-     * Creates a default config in the given workspace folder.
-     * The config is created under `.mirrord/mirrord.json`.
-     * @param folder workspace folder for the config
-     * @returns path to the created config
-     */
-    private static async createDefaultConfig(folder: vscode.WorkspaceFolder): Promise<vscode.Uri> {
-        let path = vscode.Uri.joinPath(folder.uri, ".mirrord", "mirrord.json");
-        await vscode.workspace.fs.writeFile(path, Buffer.from(DEFAULT_CONFIG));
-        return path;
+    let launchConfig = config.env?.["MIRRORD_CONFIG_FILE"];
+    if (typeof launchConfig === "string") {
+      return MirrordConfigManager.processPathFromLaunchConfig(folder, launchConfig);
     }
 
-    /**
-     * Handles `mirrord.changeSettings` command.
-     * Allows the user to open a mirrord config file selected from quick pick.
-     * Quick pick options in order:
-     *  - active config (if set)
-     *  - configs used in launch configurations across the workspace
-     *  - default configs across the workspace
-     */
-    public async changeSettings() {
-        const options: Map<string, vscode.Uri> = new Map();
-
-        // Active config first.
-        if (this.active) {
-            options.set(`(active) ${vscode.workspace.asRelativePath(this.active.path)}`, this.active);
-        }
-
-        // Then all configs found in launch configurations across the workspace.
-        const folders = vscode.workspace.workspaceFolders || [];
-        for (const folder of folders) {
-            let launchConfigs = vscode.workspace.getConfiguration("launch", folder)?.get<LaunchConfig[]>("configurations") || [];
-            for (const launchConfig of launchConfigs) {
-                let rawPath = launchConfig.env?.["MIRRORD_CONFIG_FILE"];
-                if (!rawPath) {
-                    continue;
-                }
-
-                let path;
-                if (rawPath.startsWith("/")) {
-                    path = vscode.Uri.file(rawPath);
-                } else {
-                    path = vscode.Uri.joinPath(folder.uri, rawPath);
-
-                }
-
-                if (folders.length > 1) {
-                    options.set(`(launch config ${folder.name}:${launchConfig.name}) ${vscode.workspace.asRelativePath(path)}`, path);
-                } else {
-                    options.set(`(launch config ${launchConfig.name}) ${vscode.workspace.asRelativePath(path)}`, path);
-                }
-            }
-        }
-
-        // Then all default configurations across the workspace.
-        for (const folder of folders) {
-            let path = await MirrordConfigManager.getDefaultConfig(folder);
-            if (path) {
-                options.set(`(default) ${vscode.workspace.asRelativePath(path)}`, path);
-            } else {
-                let path = vscode.Uri.joinPath(folder.uri, ".mirrord/mirrord.json");
-                options.set(`(create default) ${vscode.workspace.asRelativePath(path)}`, path);
-            }
-        }
-
-        let quickPickOptions = [...options.keys()];
-        let selected = quickPickOptions.length > 1
-            ? await vscode.window.showQuickPick(quickPickOptions, {placeHolder: "Select mirrord config to open"})
-            : quickPickOptions[0];
-
-        if (!selected) {
-            return;
-        }
-
-        let path = options.get(selected)!!;
-        if (selected.startsWith("(create default)")) {
-            await MirrordConfigManager.createDefaultConfig(vscode.workspace.getWorkspaceFolder(path)!!);
-        }
-
-        let doc = await vscode.workspace.openTextDocument(path.path);
-        vscode.window.showTextDocument(doc);
+    if (folder) {
+      let predefinedConfig = await MirrordConfigManager.getDefaultConfig(folder);
+      if (predefinedConfig) {
+        new NotificationBuilder()
+          .withMessage("using a default mirrord config")
+          .withOpenFileAction(predefinedConfig)
+          .withDisableAction("promptUsingDefaultConfig")
+          .warning();
+        return predefinedConfig;
+      }
     }
 
-    /**
-     * Resolves config file path specified in the launch config.
-     * @param folder workspace folder of the launch config
-     * @param path taken from the `MIRRORD_CONFIG_FILE` environment variable in launch config
-     * @returns config file Uri
-     */
-    private static processPathFromLaunchConfig(folder: vscode.WorkspaceFolder | undefined, path: string): vscode.Uri {
-        if (folder) {
-            path = path.replace(/\$\{workspaceFolder\}/g, folder.uri.fsPath);
-        }
-
-        return vscode.Uri.file(path);
+    folder = vscode.workspace.workspaceFolders?.[0];
+    if (!folder) {
+      throw new Error("mirrord requires an open folder in the workspace");
     }
 
-    /**
-     * Used when preparing mirrord environment for the process.
-     * @param folder optional origin of the launch config
-     * @param config debug configuration used
-     * @returns path to the mirrord config
-     */
-    public async resolveMirrordConfig(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration): Promise<vscode.Uri | null> {
-        if (this.active) {
-            new NotificationBuilder()
-                .withMessage("using active mirrord configuration")
-                .withOpenFileAction(this.active)
-                .withDisableAction("promptUsingActiveConfig")
-                .info();
-            return this.active;
-        }
-
-        let launchConfig = config.env?.["MIRRORD_CONFIG_FILE"];
-        if (typeof launchConfig === "string") {
-            return MirrordConfigManager.processPathFromLaunchConfig(folder, launchConfig);
-        }
-
-        if (folder) {
-            let predefinedConfig = await MirrordConfigManager.getDefaultConfig(folder);
-            if (predefinedConfig) {
-                new NotificationBuilder()
-                    .withMessage("using a default mirrord config")
-                    .withOpenFileAction(predefinedConfig)
-                    .withDisableAction("promptUsingDefaultConfig")
-                    .warning();
-                return predefinedConfig;
-            }
-        }
-
-        folder = vscode.workspace.workspaceFolders?.[0];
-        if (!folder) {
-            throw new Error("mirrord requires an open folder in the workspace");
-        }
-
-        let predefinedConfig = await MirrordConfigManager.getDefaultConfig(folder);
-        if (predefinedConfig) {
-            new NotificationBuilder()
-                .withMessage(`using a default mirrord config from folder ${folder.name}`)
-                .withOpenFileAction(predefinedConfig)
-                .withDisableAction("promptUsingDefaultConfig")
-                .warning();
-            return predefinedConfig;
-        }
-
-        return null;
+    let predefinedConfig = await MirrordConfigManager.getDefaultConfig(folder);
+    if (predefinedConfig) {
+      new NotificationBuilder()
+        .withMessage(`using a default mirrord config from folder ${folder.name}`)
+        .withOpenFileAction(predefinedConfig)
+        .withDisableAction("promptUsingDefaultConfig")
+        .warning();
+      return predefinedConfig;
     }
 
-    /**
-     * Checks whether mirrord target is specified in the given config.
-     * @param path config path
-     */
-    public static async isTargetInFile(path: vscode.Uri): Promise<boolean> {
-        const contents = (await vscode.workspace.fs.readFile(path)).toString();
-        let parsed;
-        if (path.path.endsWith('json')) {
-            parsed = JSON.parse(contents);
-        } else if (path.path.endsWith('yaml') || path.path.endsWith('yml')) {
-            parsed = YAML.parse(contents);
-        } else if (path.path.endsWith('toml')) {
-            parsed = TOML.parse(contents);
-        }
+    return null;
+  }
 
-        return (parsed && (typeof (parsed['target']) === 'string' || parsed['target']?.['path']));
+  /**
+   * Checks whether mirrord target is specified in the given config.
+   * @param path config path
+   */
+  public static async isTargetInFile(path: vscode.Uri): Promise<boolean> {
+    const contents = (await vscode.workspace.fs.readFile(path)).toString();
+    let parsed;
+    if (path.path.endsWith('json')) {
+      parsed = JSON.parse(contents);
+    } else if (path.path.endsWith('yaml') || path.path.endsWith('yml')) {
+      parsed = YAML.parse(contents);
+    } else if (path.path.endsWith('toml')) {
+      parsed = TOML.parse(contents);
     }
+
+    return (parsed && (typeof (parsed['target']) === 'string' || parsed['target']?.['path']));
+  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -347,22 +347,4 @@ export class MirrordConfigManager {
 
     return null;
   }
-
-  /**
-   * Checks whether mirrord target is specified in the given config.
-   * @param path config path
-   */
-  public static async isTargetInFile(path: vscode.Uri): Promise<boolean> {
-    const contents = (await vscode.workspace.fs.readFile(path)).toString();
-    let parsed;
-    if (path.path.endsWith('json')) {
-      parsed = JSON.parse(contents);
-    } else if (path.path.endsWith('yaml') || path.path.endsWith('yml')) {
-      parsed = YAML.parse(contents);
-    } else if (path.path.endsWith('toml')) {
-      parsed = TOML.parse(contents);
-    }
-
-    return (parsed && (typeof (parsed['target']) === 'string' || parsed['target']?.['path']));
-  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,20 +23,43 @@ interface LaunchConfig {
   env?: { [key: string]: string };
 }
 
+/**
+* Output from `mirrord verify-config`.
+*/
 export type VerifiedConfig = ConfigSuccess | ConfigFail;
+
+/**
+* When `mirrord verify-config` results in a `"Success"`.
+*/
 type ConfigSuccess = { 'type': 'Success', config: Config, warnings: string[] }
+
+/**
+* When `mirrord verify-config` results in a `"Fail"`.
+*/
 type ConfigFail = { 'type': 'Fail', errors: string[] }
 
+
+/**
+* When `mirrord verify-config` results in a `"Success"`, this is the config within.
+*/
 export interface Config {
   path: Path | undefined
   namespace: string | undefined
 }
 
+/**
+* Pod/deployment used to detect if `Target` was set in the config.
+*/
 export interface Path {
   deployment: string | undefined
   container: string | undefined
 }
 
+/**
+* Looks into the `verifiedConfig` to see if it has a `Target` set (by checking `Config.path`).
+*
+* Also displays warnings/errors if there are any.
+*/
 export function isTargetSet(verifiedConfig: VerifiedConfig): boolean {
   switch (verifiedConfig.type) {
     case 'Success':
@@ -46,7 +69,8 @@ export function isTargetSet(verifiedConfig: VerifiedConfig): boolean {
       verifiedConfig.errors.forEach((fail) => new NotificationBuilder().withMessage(fail).error())
       return false;
     default:
-      throw undefined;
+      let _guard: never = verifiedConfig;
+      return _guard;
   }
 
 }

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { globalContext } from './extension';
-import { MirrordConfigManager } from './config';
+import { isTargetSet, MirrordConfigManager } from './config';
 import { LAST_TARGET_KEY, MirrordAPI, mirrordFailure, MirrordExecution } from './api';
 import { updateTelemetries } from './versionCheck';
 import { getLocalMirrordBinary, getMirrordBinary } from './binaryManager';
@@ -124,8 +124,11 @@ export class ConfigurationProvider implements vscode.DebugConfigurationProvider 
 		let target = null;
 
 		let configPath = await MirrordConfigManager.getInstance().resolveMirrordConfig(folder, config);
+
+		const verifiedConfig = await mirrordApi.verifyConfig(configPath);
+
 		// If target wasn't specified in the config file (or there's no config file), let user choose pod from dropdown
-		if (!configPath || !await MirrordConfigManager.isTargetInFile(configPath)) {
+		if (!configPath || (verifiedConfig && !isTargetSet(verifiedConfig))) {
 			let targets;
 			try {
 				targets = await mirrordApi.listTargets(configPath?.path);
@@ -134,10 +137,10 @@ export class ConfigurationProvider implements vscode.DebugConfigurationProvider 
 				return null;
 			}
 			if (targets.length === 0) {
-				new NotificationBuilder()	
+				new NotificationBuilder()
 					.withMessage(
 						"No mirrord target available in the configured namespace. " +
-						"You can run targetless, or set a different target namespace or kubeconfig in the mirrord configuration file.",	
+						"You can run targetless, or set a different target namespace or kubeconfig in the mirrord configuration file.",
 					)
 					.info();
 			}
@@ -145,8 +148,8 @@ export class ConfigurationProvider implements vscode.DebugConfigurationProvider 
 			let selected = false;
 
 			while (!selected) {
-				let targetPick = await vscode.window.showQuickPick(targets.quickPickItems(), { 
-					placeHolder: 'Select a target path to mirror' 
+				let targetPick = await vscode.window.showQuickPick(targets.quickPickItems(), {
+					placeHolder: 'Select a target path to mirror'
 				});
 
 				if (targetPick) {

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -124,7 +124,6 @@ export class ConfigurationProvider implements vscode.DebugConfigurationProvider 
 		let target = null;
 
 		let configPath = await MirrordConfigManager.getInstance().resolveMirrordConfig(folder, config);
-
 		const verifiedConfig = await mirrordApi.verifyConfig(configPath);
 
 		// If target wasn't specified in the config file (or there's no config file), let user choose pod from dropdown


### PR DESCRIPTION
- Issue: #57 

Adds a task (`mirrord verify-config`) that is run when starting mirrord to check if the config file is valid, displaying warnings and errors (if any).

vscode side of [mirrord-intellij #155](https://github.com/metalbear-co/mirrord-intellij/pull/155)