### PR TITLE
Change verify config action to pass --ide, changing some target related errors to warnings.

### DIFF
--- a/changelog.d/72.fixed.md
+++ b/changelog.d/72.fixed.md
@@ -1,0 +1,1 @@
+Uses the `verify-config --ide` flag now to signal mirrord we're in an IDE context. Changes `isTargetSet` to check for both `null` and `undefined`.

--- a/src/api.ts
+++ b/src/api.ts
@@ -252,7 +252,7 @@ export class MirrordAPI {
   */
   async verifyConfig(configPath: vscode.Uri | null): Promise<VerifiedConfig | undefined> {
     if (configPath) {
-      const args = ['verify-config', '--ide2', '--path', `${configPath.path}`];
+      const args = ['verify-config', '--ide', `${configPath.path}`];
       const stdout = await this.exec(args);
 
       const verifiedConfig: VerifiedConfig = JSON.parse(stdout);

--- a/src/api.ts
+++ b/src/api.ts
@@ -188,11 +188,11 @@ export class MirrordAPI {
         }
 
         if (code) {
-          return reject(`process exited with error code: ${code} `);
+          return reject(`process exited with error code: ${code}`);
         }
 
         if (signal !== null) {
-          return reject(`process was killed by signal: ${signal} `);
+          return reject(`process was killed by signal: ${signal}`);
         }
 
         resolve(stdoutData);

--- a/src/api.ts
+++ b/src/api.ts
@@ -197,7 +197,7 @@ export class MirrordAPI {
     });
   }
 
-  /** 
+  /**
   * Spawn the mirrord cli with the given arguments.
   * Used for reading/interacting while process still runs.
   */
@@ -248,7 +248,7 @@ export class MirrordAPI {
   * `VerifiedConfig`.
   */
   async verifyConfig(configPath: vscode.Uri | null): Promise<VerifiedConfig | undefined> {
-    const args = ['verify-config', '--ide', '--path'];
+    let args = ['verify-config', '--ide', '--path'];
     if (configPath) {
       args.push(configPath.path);
       const stdout = await this.exec(args);
@@ -396,7 +396,7 @@ class MirrordWarningHandler {
   }
 }
 
-/** 
+/**
 * Updates the global feedback counter.
 * After each `FEEDBACK_COUNTER_REVIEW_AFTER` mirrord runs, displays a message asking the user to leave a review in the marketplace.
 */

--- a/src/api.ts
+++ b/src/api.ts
@@ -252,7 +252,7 @@ export class MirrordAPI {
   */
   async verifyConfig(configPath: vscode.Uri | null): Promise<VerifiedConfig | undefined> {
     if (configPath) {
-      const args = ['verify-config', '--ide', '--path', `${configPath.path}`];
+      const args = ['verify-config', '--ide2', '--path', `${configPath.path}`];
       const stdout = await this.exec(args);
 
       const verifiedConfig: VerifiedConfig = JSON.parse(stdout);

--- a/src/api.ts
+++ b/src/api.ts
@@ -248,7 +248,7 @@ export class MirrordAPI {
   * `VerifiedConfig`.
   */
   async verifyConfig(configPath: vscode.Uri | null): Promise<VerifiedConfig | undefined> {
-    const args = ['verify-config'];
+    const args = ['verify-config', '--ide', '--path'];
     if (configPath) {
       args.push(configPath.path);
       const stdout = await this.exec(args);

--- a/src/api.ts
+++ b/src/api.ts
@@ -164,6 +164,9 @@ export class MirrordAPI {
       child.stdout.on("data", (data) => stdoutData += data.toString());
       child.stderr.on("data", (data) => stderrData += data.toString());
 
+      child.stdout.on('end', () => console.log(`${stdoutData}`));
+      child.stderr.on('end', () => console.log(`${stderrData}`));
+
       child.on("error", (err) => {
         console.error(err);
         reject(`process failed: ${err.message}`);
@@ -185,11 +188,11 @@ export class MirrordAPI {
         }
 
         if (code) {
-          return reject(`process exited with error code: ${code}`);
+          return reject(`process exited with error code: ${code} `);
         }
 
         if (signal !== null) {
-          return reject(`process was killed by signal: ${signal}`);
+          return reject(`process was killed by signal: ${signal} `);
         }
 
         resolve(stdoutData);
@@ -244,13 +247,12 @@ export class MirrordAPI {
   }
 
   /**
-  * Executes the `mirrord verify-config {configPath}` command, parsing its output into a
+  * Executes the `mirrord verify - config { configPath } ` command, parsing its output into a
   * `VerifiedConfig`.
   */
   async verifyConfig(configPath: vscode.Uri | null): Promise<VerifiedConfig | undefined> {
-    let args = ['verify-config', '--ide', '--path'];
     if (configPath) {
-      args.push(configPath.path);
+      const args = ['verify-config', '--ide', '--path', `${configPath.path}`];
       const stdout = await this.exec(args);
 
       const verifiedConfig: VerifiedConfig = JSON.parse(stdout);
@@ -296,7 +298,7 @@ export class MirrordAPI {
 
         child.on("error", (err) => {
           console.error(err);
-          reject(`process failed: ${err.message}`);
+          reject(`process failed: ${err.message} `);
         });
 
         child.on("close", (code, signal) => {
@@ -304,7 +306,7 @@ export class MirrordAPI {
           if (match) {
             const error = JSON.parse(match);
             const notification = new NotificationBuilder()
-              .withMessage(`mirrord error: ${error["message"]}`);
+              .withMessage(`mirrord error: ${error["message"]} `);
             if (error["help"]) {
               notification.withGenericAction("Help", async () => {
                 vscode.window.showInformationMessage(error["help"]);
@@ -315,11 +317,11 @@ export class MirrordAPI {
           }
 
           if (code) {
-            return reject(`process exited with error code: ${code}`);
+            return reject(`process exited with error code: ${code} `);
           }
 
           if (signal !== null) {
-            return reject(`process was killed by signal: ${signal}`);
+            return reject(`process was killed by signal: ${signal} `);
           }
         });
 
@@ -327,7 +329,7 @@ export class MirrordAPI {
 
         let buffer = "";
         child.stdout.on("data", (data) => {
-          console.log(`mirrord: ${data}`);
+          console.log(`mirrord: ${data} `);
           buffer += data;
           // fml - AH
           let messages = buffer.split("\n");
@@ -408,7 +410,7 @@ function tickFeedbackCounter() {
 
   if ((currentRuns % FEEDBACK_COUNTER_REVIEW_AFTER) === 0) {
     new NotificationBuilder()
-      .withMessage(`Enjoying mirrord? Don't forget to leave a review! Also consider giving us some feedback, we'd highly appreciate it!`)
+      .withMessage(`Enjoying mirrord ? Don't forget to leave a review! Also consider giving us some feedback, we'd highly appreciate it!`)
       .withGenericAction("Review", async () => {
         vscode.env.openExternal(
           vscode.Uri.parse('https://marketplace.visualstudio.com/items?itemName=MetalBear.mirrord&ssr=false#review-details')

--- a/src/api.ts
+++ b/src/api.ts
@@ -247,7 +247,7 @@ export class MirrordAPI {
   }
 
   /**
-  * Executes the `mirrord verify - config { configPath } ` command, parsing its output into a
+  * Executes the `mirrord verify-config {configPath}` command, parsing its output into a
   * `VerifiedConfig`.
   */
   async verifyConfig(configPath: vscode.Uri | null): Promise<VerifiedConfig | undefined> {
@@ -298,7 +298,7 @@ export class MirrordAPI {
 
         child.on("error", (err) => {
           console.error(err);
-          reject(`process failed: ${err.message} `);
+          reject(`process failed: ${err.message}`);
         });
 
         child.on("close", (code, signal) => {
@@ -306,7 +306,7 @@ export class MirrordAPI {
           if (match) {
             const error = JSON.parse(match);
             const notification = new NotificationBuilder()
-              .withMessage(`mirrord error: ${error["message"]} `);
+              .withMessage(`mirrord error: ${error["message"]}`);
             if (error["help"]) {
               notification.withGenericAction("Help", async () => {
                 vscode.window.showInformationMessage(error["help"]);
@@ -317,11 +317,11 @@ export class MirrordAPI {
           }
 
           if (code) {
-            return reject(`process exited with error code: ${code} `);
+            return reject(`process exited with error code: ${code}`);
           }
 
           if (signal !== null) {
-            return reject(`process was killed by signal: ${signal} `);
+            return reject(`process was killed by signal: ${signal}`);
           }
         });
 
@@ -329,7 +329,7 @@ export class MirrordAPI {
 
         let buffer = "";
         child.stdout.on("data", (data) => {
-          console.log(`mirrord: ${data} `);
+          console.log(`mirrord: ${data}`);
           buffer += data;
           // fml - AH
           let messages = buffer.split("\n");
@@ -410,7 +410,7 @@ function tickFeedbackCounter() {
 
   if ((currentRuns % FEEDBACK_COUNTER_REVIEW_AFTER) === 0) {
     new NotificationBuilder()
-      .withMessage(`Enjoying mirrord ? Don't forget to leave a review! Also consider giving us some feedback, we'd highly appreciate it!`)
+      .withMessage(`Enjoying mirrord? Don't forget to leave a review! Also consider giving us some feedback, we'd highly appreciate it!`)
       .withGenericAction("Review", async () => {
         vscode.env.openExternal(
           vscode.Uri.parse('https://marketplace.visualstudio.com/items?itemName=MetalBear.mirrord&ssr=false#review-details')

--- a/src/config.ts
+++ b/src/config.ts
@@ -69,7 +69,7 @@ export function isTargetSet(verifiedConfig: VerifiedConfig): boolean {
   switch (verifiedConfig.type) {
     case 'Success':
       verifiedConfig.warnings.forEach((warn) => new NotificationBuilder().withMessage(warn).warning());
-      return verifiedConfig.config.path !== undefined;
+      return verifiedConfig.config.path !== undefined && verifiedConfig.config.path !== null;
     case 'Fail':
       verifiedConfig.errors.forEach((fail) => new NotificationBuilder().withMessage(fail).error());
       throw new Error('mirrord verify-config detected an invalid configuration!');

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,5 @@
 import * as vscode from 'vscode';
-import YAML from 'yaml';
-import TOML from 'toml';
 import { NotificationBuilder } from './notification';
-import { mirrordFailure } from './api';
 
 /**
  * Default mirrord configuration.

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -85,6 +85,139 @@ function setLastActiveMirrordPath(path: string) {
 }
 
 /**
+* Entrypoint for the vscode extension, called from `resolveDebugConfigurationWithSubstitutedVariables`.
+*/
+async function main(
+	folder: vscode.WorkspaceFolder | undefined,
+	config: vscode.DebugConfiguration,
+	_token: vscode.CancellationToken): Promise<vscode.DebugConfiguration | null | undefined> {
+	if (!globalContext.workspaceState.get('enabled')) {
+		return config;
+	}
+
+	// For some reason resolveDebugConfiguration runs twice for Node projects. __parentId is populated.
+	if (config.__parentId || config.env?.["__MIRRORD_EXT_INJECTED"] === 'true') {
+		return config;
+	}
+
+	updateTelemetries();
+
+	//TODO: add progress bar maybe ?
+	let cliPath;
+
+	try {
+		cliPath = await getMirrordBinary();
+	} catch (err) {
+		// Get last active, that should work?
+		cliPath = await getLastActiveMirrordPath();
+
+		// Well try any mirrord we can try :\
+		if (!cliPath) {
+			cliPath = await getLocalMirrordBinary();
+			if (!cliPath) {
+				mirrordFailure(`Couldn't download mirrord binaries or find local one in path ${err}.`);
+				return null;
+			}
+		}
+	}
+	setLastActiveMirrordPath(cliPath);
+
+	let mirrordApi = new MirrordAPI(cliPath);
+
+	config.env ||= {};
+	let target = null;
+
+	let configPath = await MirrordConfigManager.getInstance().resolveMirrordConfig(folder, config);
+	const verifiedConfig = await mirrordApi.verifyConfig(configPath);
+
+	// If target wasn't specified in the config file (or there's no config file), let user choose pod from dropdown
+	if (!configPath || (verifiedConfig && !isTargetSet(verifiedConfig))) {
+		let targets;
+		try {
+			targets = await mirrordApi.listTargets(configPath?.path);
+		} catch (err) {
+			mirrordFailure(`mirrord failed to list targets: ${err}`);
+			return null;
+		}
+		if (targets.length === 0) {
+			new NotificationBuilder()
+				.withMessage(
+					"No mirrord target available in the configured namespace. " +
+					"You can run targetless, or set a different target namespace or kubeconfig in the mirrord configuration file.",
+				)
+				.info();
+		}
+
+		let selected = false;
+
+		while (!selected) {
+			let targetPick = await vscode.window.showQuickPick(targets.quickPickItems(), {
+				placeHolder: 'Select a target path to mirror'
+			});
+
+			if (targetPick) {
+				if (targetPick.type === 'page') {
+					targets.switchPage(targetPick);
+
+					continue;
+				}
+
+				if (targetPick.type !== 'targetless') {
+					target = targetPick.value;
+				}
+
+				globalContext.globalState.update(LAST_TARGET_KEY, target);
+				globalContext.workspaceState.update(LAST_TARGET_KEY, target);
+			}
+
+			selected = true;
+		}
+
+		if (!target) {
+			new NotificationBuilder()
+				.withMessage("mirrord running targetless")
+				.withDisableAction("promptTargetless")
+				.info();
+		}
+	}
+
+	if (config.type === "go") {
+		config.env["MIRRORD_SKIP_PROCESSES"] = "dlv;debugserver;compile;go;asm;cgo;link;git;gcc;as;ld;collect2;cc1";
+	} else if (config.type === "python") {
+		config.env["MIRRORD_DETECT_DEBUGGER_PORT"] = "debugpy";
+	} else if (config.type === "java") {
+		config.env["MIRRORD_DETECT_DEBUGGER_PORT"] = "javaagent";
+	}
+
+	// Add a fixed range of ports that VS Code uses for debugging.
+	// TODO: find a way to use MIRRORD_DETECT_DEBUGGER_PORT for other debuggers.
+	config.env["MIRRORD_IGNORE_DEBUGGER_PORTS"] = "45000-65535";
+
+	let isMac = platform() === "darwin";
+
+	let [executableFieldName, executable] = isMac ? getFieldAndExecutable(config) : [null, null];
+
+	let executionInfo;
+	try {
+		executionInfo = await mirrordApi.binaryExecute(target, configPath?.path || null, executable);
+	} catch (err) {
+		mirrordFailure(`mirrord preparation failed: ${err}`);
+		return null;
+	}
+
+	if (isMac) {
+		changeConfigForSip(config, executableFieldName as string, executionInfo);
+	}
+
+	let env = executionInfo?.env;
+	config.env = Object.assign({}, config.env, Object.fromEntries(env));
+
+	config.env["__MIRRORD_EXT_INJECTED"] = 'true';
+
+	return config;
+}
+
+/**
 * We implement the `resolveDebugConfiguration` that comes with vscode variables resolved already.
 */
 export class ConfigurationProvider implements vscode.DebugConfigurationProvider {
@@ -93,130 +226,7 @@ export class ConfigurationProvider implements vscode.DebugConfigurationProvider 
 		config: vscode.DebugConfiguration,
 		_token: vscode.CancellationToken): Promise<vscode.DebugConfiguration | null | undefined> {
 		try {
-			if (!globalContext.workspaceState.get('enabled')) {
-				return config;
-			}
-
-			// For some reason resolveDebugConfiguration runs twice for Node projects. __parentId is populated.
-			if (config.__parentId || config.env?.["__MIRRORD_EXT_INJECTED"] === 'true') {
-				return config;
-			}
-
-			updateTelemetries();
-
-			//TODO: add progress bar maybe ?
-			let cliPath;
-
-			try {
-				cliPath = await getMirrordBinary();
-			} catch (err) {
-				// Get last active, that should work?
-				cliPath = await getLastActiveMirrordPath();
-
-				// Well try any mirrord we can try :\
-				if (!cliPath) {
-					cliPath = await getLocalMirrordBinary();
-					if (!cliPath) {
-						mirrordFailure(`Couldn't download mirrord binaries or find local one in path ${err}.`);
-						return null;
-					}
-				}
-			}
-			setLastActiveMirrordPath(cliPath);
-
-			let mirrordApi = new MirrordAPI(cliPath);
-
-			config.env ||= {};
-			let target = null;
-
-			let configPath = await MirrordConfigManager.getInstance().resolveMirrordConfig(folder, config);
-			const verifiedConfig = await mirrordApi.verifyConfig(configPath);
-
-			// If target wasn't specified in the config file (or there's no config file), let user choose pod from dropdown
-			if (!configPath || (verifiedConfig && !isTargetSet(verifiedConfig))) {
-				let targets;
-				try {
-					targets = await mirrordApi.listTargets(configPath?.path);
-				} catch (err) {
-					mirrordFailure(`mirrord failed to list targets: ${err}`);
-					return null;
-				}
-				if (targets.length === 0) {
-					new NotificationBuilder()
-						.withMessage(
-							"No mirrord target available in the configured namespace. " +
-							"You can run targetless, or set a different target namespace or kubeconfig in the mirrord configuration file.",
-						)
-						.info();
-				}
-
-				let selected = false;
-
-				while (!selected) {
-					let targetPick = await vscode.window.showQuickPick(targets.quickPickItems(), {
-						placeHolder: 'Select a target path to mirror'
-					});
-
-					if (targetPick) {
-						if (targetPick.type === 'page') {
-							targets.switchPage(targetPick);
-
-							continue;
-						}
-
-						if (targetPick.type !== 'targetless') {
-							target = targetPick.value;
-						}
-
-						globalContext.globalState.update(LAST_TARGET_KEY, target);
-						globalContext.workspaceState.update(LAST_TARGET_KEY, target);
-					}
-
-					selected = true;
-				}
-
-				if (!target) {
-					new NotificationBuilder()
-						.withMessage("mirrord running targetless")
-						.withDisableAction("promptTargetless")
-						.info();
-				}
-			}
-
-			if (config.type === "go") {
-				config.env["MIRRORD_SKIP_PROCESSES"] = "dlv;debugserver;compile;go;asm;cgo;link;git;gcc;as;ld;collect2;cc1";
-			} else if (config.type === "python") {
-				config.env["MIRRORD_DETECT_DEBUGGER_PORT"] = "debugpy";
-			} else if (config.type === "java") {
-				config.env["MIRRORD_DETECT_DEBUGGER_PORT"] = "javaagent";
-			}
-
-			// Add a fixed range of ports that VS Code uses for debugging.
-			// TODO: find a way to use MIRRORD_DETECT_DEBUGGER_PORT for other debuggers.
-			config.env["MIRRORD_IGNORE_DEBUGGER_PORTS"] = "45000-65535";
-
-			let isMac = platform() === "darwin";
-
-			let [executableFieldName, executable] = isMac ? getFieldAndExecutable(config) : [null, null];
-
-			let executionInfo;
-			try {
-				executionInfo = await mirrordApi.binaryExecute(target, configPath?.path || null, executable);
-			} catch (err) {
-				mirrordFailure(`mirrord preparation failed: ${err}`);
-				return null;
-			}
-
-			if (isMac) {
-				changeConfigForSip(config, executableFieldName as string, executionInfo);
-			}
-
-			let env = executionInfo?.env;
-			config.env = Object.assign({}, config.env, Object.fromEntries(env));
-
-			config.env["__MIRRORD_EXT_INJECTED"] = 'true';
-
-			return config;
+			return await main(folder, config, _token);
 		} catch (fail) {
 			console.error(`Something went wrong in the extension: ${fail}`);
 			new NotificationBuilder()

--- a/src/tests/e2e.ts
+++ b/src/tests/e2e.ts
@@ -49,7 +49,7 @@ describe("mirrord sample flow test", function() {
 
             return true;
           }
-        } catch (e) { console.error(`Something went wrong ${e}`) }
+        } catch (e) { console.error(`Something went wrong ${e}`); }
       }
     }, defaultTimeout, "mirrord `enable` button not found -- timed out");
 
@@ -59,7 +59,7 @@ describe("mirrord sample flow test", function() {
           if ((await button.getText()).startsWith('mirrord')) {
             return true;
           }
-        } catch (e) { console.error(`Something went wrong ${e}`) }
+        } catch (e) { console.error(`Something went wrong ${e}`); }
       }
     }, defaultTimeout, "mirrord `disable` button not found -- timed out");
   });


### PR DESCRIPTION
- Issue: [#1979](https://github.com/metalbear-co/mirrord/issues/1979)

Uses `mirrord verify-config --ide --path` now.

Wraps the entry-point in a `try/catch` block so we don't silently fail when `exec` goes wrong.

vscode side of [#168](https://github.com/metalbear-co/mirrord-intellij/pull/168)