### PR TITLE
Pass config env vars to mirrord verify-config.

### DIFF
--- a/changelog.d/70.fixed.md
+++ b/changelog.d/70.fixed.md
@@ -1,0 +1,1 @@
+Passes the `launch.json` `env` section to `mirrord verify-config`, resolving config options that were set as env vars. 

--- a/src/api.ts
+++ b/src/api.ts
@@ -309,7 +309,6 @@ export class MirrordAPI {
           reject("timeout");
         }, 120 * 1000);
 
-        target = null;
         const args = makeMirrordArgs(target, configFile, executable);
 
         const child = this.spawnCliWithArgsAndEnv(args, configEnv);

--- a/src/api.ts
+++ b/src/api.ts
@@ -172,10 +172,10 @@ export class MirrordAPI {
   private static getEnv(configEnv: EnvVars): NodeJS.ProcessEnv {
     // clone env vars and add MIRRORD_PROGRESS_MODE
     return {
+      ...process.env,
+      ...configEnv,
       // eslint-disable-next-line @typescript-eslint/naming-convention
       "MIRRORD_PROGRESS_MODE": "json",
-      ...configEnv,
-      ...process.env,
     };
   }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -134,18 +134,24 @@ export class MirrordExecution {
 
 }
 
+/**
+* Sets up the args that are going to be passed to the mirrord cli.
+*/
 const makeMirrordArgs = (target: string | null, configFilePath: PathLike | null, userExecutable: PathLike | null): readonly string[] => {
   let args = ["ext"];
 
   if (target) {
+    console.log(`target ${target}`);
     args.push("-t", target);
   }
 
   if (configFilePath) {
+    console.log(`configFilePath ${configFilePath.toString()}`);
     args.push("-f", configFilePath.toString());
   }
 
   if (userExecutable) {
+    console.log(`userExecutable ${userExecutable.toString()}`);
     args.push("-e", userExecutable.toString());
   }
 
@@ -282,9 +288,12 @@ export class MirrordAPI {
     }
   }
 
-  // Run the extension execute sequence
-  // Creating agent and gathering execution runtime (env vars to set)
-  // Has 60 seconds timeout
+  /** 
+  * Runs the extension execute sequence, creating agent and gathering execution runtime while also
+  * setting env vars, both from system, and from `launch.json` (`configEnv`).
+  *
+  * Has 60 seconds timeout
+  */
   async binaryExecute(target: string | null, configFile: string | null, executable: string | null, configEnv: EnvVars): Promise<MirrordExecution> {
     tickWaitlistCounter(!!target?.startsWith('deployment/'));
     tickFeedbackCounter();

--- a/src/api.ts
+++ b/src/api.ts
@@ -266,7 +266,8 @@ export class MirrordAPI {
   // Run the extension execute sequence
   // Creating agent and gathering execution runtime (env vars to set)
   // Has 60 seconds timeout
-  async binaryExecute(target: string | null, configFile: string | null, executable: string | null): Promise<MirrordExecution> {
+  async binaryExecute(target: string | null, configFile: string | null, executable: string | null, configEnv: EnvVars): Promise<MirrordExecution> {
+    console.log(`do we have a target here ${target}`);
     tickWaitlistCounter(!!target?.startsWith('deployment/'));
     tickFeedbackCounter();
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,9 +16,11 @@ const DEFAULT_CONFIG = `{
 }
 `;
 
+export type EnvVars = { [key: string]: string };
+
 interface LaunchConfig {
   name: string,
-  env?: { [key: string]: string };
+  env?: EnvVars;
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -300,13 +300,9 @@ export class MirrordConfigManager {
         .withDisableAction("promptUsingActiveConfig")
         .info();
       return this.active;
-    }
-
-    if (config.env?.["MIRRORD_CONFIG_FILE"]) {
+    } else if (config.env?.["MIRRORD_CONFIG_FILE"]) {
       return vscode.Uri.parse(`file://${config.env?.["MIRRORD_CONFIG_FILE"]}`, true);
-    }
-
-    if (folder) {
+    } else if (folder) {
       let predefinedConfig = await MirrordConfigManager.getDefaultConfig(folder);
       if (predefinedConfig) {
         new NotificationBuilder()
@@ -315,24 +311,26 @@ export class MirrordConfigManager {
           .withDisableAction("promptUsingDefaultConfig")
           .warning();
         return predefinedConfig;
+      } else {
+        return null;
+      }
+    } else {
+      folder = vscode.workspace.workspaceFolders?.[0];
+      if (!folder) {
+        throw new Error("mirrord requires an open folder in the workspace");
+      }
+
+      let predefinedConfig = await MirrordConfigManager.getDefaultConfig(folder);
+      if (predefinedConfig) {
+        new NotificationBuilder()
+          .withMessage(`using a default mirrord config from folder ${folder.name} `)
+          .withOpenFileAction(predefinedConfig)
+          .withDisableAction("promptUsingDefaultConfig")
+          .warning();
+        return predefinedConfig;
+      } else {
+        return null;
       }
     }
-
-    folder = vscode.workspace.workspaceFolders?.[0];
-    if (!folder) {
-      throw new Error("mirrord requires an open folder in the workspace");
-    }
-
-    let predefinedConfig = await MirrordConfigManager.getDefaultConfig(folder);
-    if (predefinedConfig) {
-      new NotificationBuilder()
-        .withMessage(`using a default mirrord config from folder ${folder.name} `)
-        .withOpenFileAction(predefinedConfig)
-        .withDisableAction("promptUsingDefaultConfig")
-        .warning();
-      return predefinedConfig;
-    }
-
-    return null;
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -287,20 +287,6 @@ export class MirrordConfigManager {
   }
 
   /**
-   * Resolves config file path specified in the launch config.
-   * @param folder workspace folder of the launch config
-   * @param path taken from the `MIRRORD_CONFIG_FILE` environment variable in launch config
-   * @returns config file Uri
-   */
-  private static processPathFromLaunchConfig(folder: vscode.WorkspaceFolder | undefined, path: string): vscode.Uri {
-    if (folder) {
-      path = path.replace(/\$\{workspaceFolder\}/g, folder.uri.fsPath);
-    }
-
-    return vscode.Uri.file(path);
-  }
-
-  /**
    * Used when preparing mirrord environment for the process.
    * @param folder optional origin of the launch config
    * @param config debug configuration used
@@ -316,9 +302,8 @@ export class MirrordConfigManager {
       return this.active;
     }
 
-    let launchConfig = config.env?.["MIRRORD_CONFIG_FILE"];
-    if (typeof launchConfig === "string") {
-      return MirrordConfigManager.processPathFromLaunchConfig(folder, launchConfig);
+    if (config.env?.["MIRRORD_CONFIG_FILE"]) {
+      return vscode.Uri.parse(`file://${config.env?.["MIRRORD_CONFIG_FILE"]}`, true);
     }
 
     if (folder) {
@@ -341,7 +326,7 @@ export class MirrordConfigManager {
     let predefinedConfig = await MirrordConfigManager.getDefaultConfig(folder);
     if (predefinedConfig) {
       new NotificationBuilder()
-        .withMessage(`using a default mirrord config from folder ${folder.name}`)
+        .withMessage(`using a default mirrord config from folder ${folder.name} `)
         .withOpenFileAction(predefinedConfig)
         .withDisableAction("promptUsingDefaultConfig")
         .warning();

--- a/src/config.ts
+++ b/src/config.ts
@@ -294,6 +294,7 @@ export class MirrordConfigManager {
    */
   public async resolveMirrordConfig(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration): Promise<vscode.Uri | null> {
     if (this.active) {
+      // User has selected a config (via active config button).
       new NotificationBuilder()
         .withMessage("using active mirrord configuration")
         .withOpenFileAction(this.active)
@@ -301,6 +302,7 @@ export class MirrordConfigManager {
         .info();
       return this.active;
     } else if (config.env?.["MIRRORD_CONFIG_FILE"]) {
+      // Get the config path from the env var.
       return vscode.Uri.parse(`file://${config.env?.["MIRRORD_CONFIG_FILE"]}`, true);
     } else if (folder) {
       let predefinedConfig = await MirrordConfigManager.getDefaultConfig(folder);

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -95,17 +95,17 @@ async function main(
     return config;
   }
 
-	if (config.request === "attach") {
-		new NotificationBuilder()
-			.withMessage("mirrord cannot be used with `attach` launch configurations")
-			.error();
-		return null;
-	}
+  if (config.request === "attach") {
+    new NotificationBuilder()
+      .withMessage("mirrord cannot be used with `attach` launch configurations")
+      .error();
+    return null;
+  }
 
-	// For some reason resolveDebugConfiguration runs twice for Node projects. __parentId is populated.
-	if (config.__parentId || config.env?.["__MIRRORD_EXT_INJECTED"] === 'true') {
-		return config;
-	}
+  // For some reason resolveDebugConfiguration runs twice for Node projects. __parentId is populated.
+  if (config.__parentId || config.env?.["__MIRRORD_EXT_INJECTED"] === 'true') {
+    return config;
+  }
 
   updateTelemetries();
 

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -199,7 +199,7 @@ async function main(
 
 	let executionInfo;
 	try {
-		executionInfo = await mirrordApi.binaryExecute(target, configPath?.path || null, executable);
+		executionInfo = await mirrordApi.binaryExecute(target, configPath?.path || null, executable, config.env);
 	} catch (err) {
 		mirrordFailure(`mirrord preparation failed: ${err}`);
 		return null;

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -128,7 +128,7 @@ async function main(
 	let target = null;
 
 	let configPath = await MirrordConfigManager.getInstance().resolveMirrordConfig(folder, config);
-	const verifiedConfig = await mirrordApi.verifyConfig(configPath);
+	const verifiedConfig = await mirrordApi.verifyConfig(configPath, config.env);
 
 	// If target wasn't specified in the config file (or there's no config file), let user choose pod from dropdown
 	if (!configPath || (verifiedConfig && !isTargetSet(verifiedConfig))) {

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -14,224 +14,224 @@ const DYLD_ENV_VAR_NAME = "DYLD_INSERT_LIBRARIES";
 /// Also returning the executable because in some configuration types there is some extra logic to
 /// be done for retrieving the executable out of its field (see the `node-terminal` case).
 function getFieldAndExecutable(config: vscode.DebugConfiguration): [keyof vscode.DebugConfiguration, string | null] {
-	switch (config.type) {
-		case "pwa-node":
-		case "node": {
-			// https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_launch-configuration-attributes
-			return ["runtimeExecutable", config["runtimeExecutable"]];
-		}
-		case "node-terminal": {
-			// Command could contain multiple commands like "command1 arg1; command2 arg2", so we execute that command
-			// in a shell, to which we inject the layer. In order to inject the layer to the shell, we have to patch it
-			// for SIP, so we pass the shell to the mirrod CLI.
-			return ["command", vscode.env.shell];
-		}
-		case "python": {
-			if ("python" in config) {
-				return ["python", config["python"]];
-			}
-			// Official documentation states the relevant field name is "python" (https://code.visualstudio.com/docs/python/debugging#_python), 
-			// but when debugging we see the field is called "pythonPath".
-			return ["pythonPath", config["pythonPath"]];
-		}
-		default: {
-			return ["program", config["program"]];
-		}
-	}
+  switch (config.type) {
+    case "pwa-node":
+    case "node": {
+      // https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_launch-configuration-attributes
+      return ["runtimeExecutable", config["runtimeExecutable"]];
+    }
+    case "node-terminal": {
+      // Command could contain multiple commands like "command1 arg1; command2 arg2", so we execute that command
+      // in a shell, to which we inject the layer. In order to inject the layer to the shell, we have to patch it
+      // for SIP, so we pass the shell to the mirrod CLI.
+      return ["command", vscode.env.shell];
+    }
+    case "python": {
+      if ("python" in config) {
+        return ["python", config["python"]];
+      }
+      // Official documentation states the relevant field name is "python" (https://code.visualstudio.com/docs/python/debugging#_python), 
+      // but when debugging we see the field is called "pythonPath".
+      return ["pythonPath", config["pythonPath"]];
+    }
+    default: {
+      return ["program", config["program"]];
+    }
+  }
 }
 
 /// Edit the launch configuration in order to sidestep SIP on macOS, and allow the layer to be
 /// loaded into the process. This includes replacing the executable with the path to a patched
 /// executable if the original executable is SIP protected, and some other special workarounds.
 function changeConfigForSip(config: vscode.DebugConfiguration, executableFieldName: string, executionInfo: MirrordExecution) {
-	if (config.type === "node-terminal") {
-		const command = config[executableFieldName];
-		if (command === null) {
-			return;
-		}
+  if (config.type === "node-terminal") {
+    const command = config[executableFieldName];
+    if (command === null) {
+      return;
+    }
 
-		// The command could have single quotes, and we are putting the whole command in single quotes in the changed command.
-		// So we replace each `'` with `'\''` (closes the string, concats an escaped single quote, opens the string)
-		const escapedCommand = command.replaceAll("'", "'\\''");
-		const sh = executionInfo.patchedPath ?? vscode.env.shell;
+    // The command could have single quotes, and we are putting the whole command in single quotes in the changed command.
+    // So we replace each `'` with `'\''` (closes the string, concats an escaped single quote, opens the string)
+    const escapedCommand = command.replaceAll("'", "'\\''");
+    const sh = executionInfo.patchedPath ?? vscode.env.shell;
 
-		const libraryPath = executionInfo.env.get(DYLD_ENV_VAR_NAME);
+    const libraryPath = executionInfo.env.get(DYLD_ENV_VAR_NAME);
 
-		// Run the command in a SIP-patched shell, that way everything that runs in the original command will be SIP-patched
-		// on runtime.
-		config[executableFieldName] = `echo '${escapedCommand}' | ${DYLD_ENV_VAR_NAME}=${libraryPath} ${sh} -is`;
-	} else if (executionInfo.patchedPath !== null) {
-		config[executableFieldName] = executionInfo.patchedPath!;
-	}
+    // Run the command in a SIP-patched shell, that way everything that runs in the original command will be SIP-patched
+    // on runtime.
+    config[executableFieldName] = `echo '${escapedCommand}' | ${DYLD_ENV_VAR_NAME}=${libraryPath} ${sh} -is`;
+  } else if (executionInfo.patchedPath !== null) {
+    config[executableFieldName] = executionInfo.patchedPath!;
+  }
 }
 
 
 
 async function getLastActiveMirrordPath(): Promise<string | null> {
-	const binaryPath = globalContext.globalState.get('binaryPath', null);
-	if (!binaryPath) {
-		return null;
-	}
-	try {
-		await vscode.workspace.fs.stat(binaryPath);
-		return binaryPath;
-	} catch (e) {
-		return null;
-	}
+  const binaryPath = globalContext.globalState.get('binaryPath', null);
+  if (!binaryPath) {
+    return null;
+  }
+  try {
+    await vscode.workspace.fs.stat(binaryPath);
+    return binaryPath;
+  } catch (e) {
+    return null;
+  }
 }
 
 function setLastActiveMirrordPath(path: string) {
-	globalContext.globalState.update('binaryPath', path);
+  globalContext.globalState.update('binaryPath', path);
 }
 
 /**
 * Entrypoint for the vscode extension, called from `resolveDebugConfigurationWithSubstitutedVariables`.
 */
 async function main(
-	folder: vscode.WorkspaceFolder | undefined,
-	config: vscode.DebugConfiguration,
-	_token: vscode.CancellationToken): Promise<vscode.DebugConfiguration | null | undefined> {
-	if (!globalContext.workspaceState.get('enabled')) {
-		return config;
-	}
+  folder: vscode.WorkspaceFolder | undefined,
+  config: vscode.DebugConfiguration,
+  _token: vscode.CancellationToken): Promise<vscode.DebugConfiguration | null | undefined> {
+  if (!globalContext.workspaceState.get('enabled')) {
+    return config;
+  }
 
-	// For some reason resolveDebugConfiguration runs twice for Node projects. __parentId is populated.
-	if (config.__parentId || config.env?.["__MIRRORD_EXT_INJECTED"] === 'true') {
-		return config;
-	}
+  // For some reason resolveDebugConfiguration runs twice for Node projects. __parentId is populated.
+  if (config.__parentId || config.env?.["__MIRRORD_EXT_INJECTED"] === 'true') {
+    return config;
+  }
 
-	updateTelemetries();
+  updateTelemetries();
 
-	//TODO: add progress bar maybe ?
-	let cliPath;
+  //TODO: add progress bar maybe ?
+  let cliPath;
 
-	try {
-		cliPath = await getMirrordBinary();
-	} catch (err) {
-		// Get last active, that should work?
-		cliPath = await getLastActiveMirrordPath();
+  try {
+    cliPath = await getMirrordBinary();
+  } catch (err) {
+    // Get last active, that should work?
+    cliPath = await getLastActiveMirrordPath();
 
-		// Well try any mirrord we can try :\
-		if (!cliPath) {
-			cliPath = await getLocalMirrordBinary();
-			if (!cliPath) {
-				mirrordFailure(`Couldn't download mirrord binaries or find local one in path ${err}.`);
-				return null;
-			}
-		}
-	}
-	setLastActiveMirrordPath(cliPath);
+    // Well try any mirrord we can try :\
+    if (!cliPath) {
+      cliPath = await getLocalMirrordBinary();
+      if (!cliPath) {
+        mirrordFailure(`Couldn't download mirrord binaries or find local one in path ${err}.`);
+        return null;
+      }
+    }
+  }
+  setLastActiveMirrordPath(cliPath);
 
-	let mirrordApi = new MirrordAPI(cliPath);
+  let mirrordApi = new MirrordAPI(cliPath);
 
-	config.env ||= {};
-	let target = null;
+  config.env ||= {};
+  let target = null;
 
-	let configPath = await MirrordConfigManager.getInstance().resolveMirrordConfig(folder, config);
-	const verifiedConfig = await mirrordApi.verifyConfig(configPath, config.env);
+  let configPath = await MirrordConfigManager.getInstance().resolveMirrordConfig(folder, config);
+  const verifiedConfig = await mirrordApi.verifyConfig(configPath, config.env);
 
-	// If target wasn't specified in the config file (or there's no config file), let user choose pod from dropdown
-	if (!configPath || (verifiedConfig && !isTargetSet(verifiedConfig))) {
-		let targets;
-		try {
-			targets = await mirrordApi.listTargets(configPath?.path);
-		} catch (err) {
-			mirrordFailure(`mirrord failed to list targets: ${err}`);
-			return null;
-		}
-		if (targets.length === 0) {
-			new NotificationBuilder()
-				.withMessage(
-					"No mirrord target available in the configured namespace. " +
-					"You can run targetless, or set a different target namespace or kubeconfig in the mirrord configuration file.",
-				)
-				.info();
-		}
+  // If target wasn't specified in the config file (or there's no config file), let user choose pod from dropdown
+  if (!configPath || (verifiedConfig && !isTargetSet(verifiedConfig))) {
+    let targets;
+    try {
+      targets = await mirrordApi.listTargets(configPath?.path);
+    } catch (err) {
+      mirrordFailure(`mirrord failed to list targets: ${err}`);
+      return null;
+    }
+    if (targets.length === 0) {
+      new NotificationBuilder()
+        .withMessage(
+          "No mirrord target available in the configured namespace. " +
+          "You can run targetless, or set a different target namespace or kubeconfig in the mirrord configuration file.",
+        )
+        .info();
+    }
 
-		let selected = false;
+    let selected = false;
 
-		while (!selected) {
-			let targetPick = await vscode.window.showQuickPick(targets.quickPickItems(), {
-				placeHolder: 'Select a target path to mirror'
-			});
+    while (!selected) {
+      let targetPick = await vscode.window.showQuickPick(targets.quickPickItems(), {
+        placeHolder: 'Select a target path to mirror'
+      });
 
-			if (targetPick) {
-				if (targetPick.type === 'page') {
-					targets.switchPage(targetPick);
+      if (targetPick) {
+        if (targetPick.type === 'page') {
+          targets.switchPage(targetPick);
 
-					continue;
-				}
+          continue;
+        }
 
-				if (targetPick.type !== 'targetless') {
-					target = targetPick.value;
-				}
+        if (targetPick.type !== 'targetless') {
+          target = targetPick.value;
+        }
 
-				globalContext.globalState.update(LAST_TARGET_KEY, target);
-				globalContext.workspaceState.update(LAST_TARGET_KEY, target);
-			}
+        globalContext.globalState.update(LAST_TARGET_KEY, target);
+        globalContext.workspaceState.update(LAST_TARGET_KEY, target);
+      }
 
-			selected = true;
-		}
+      selected = true;
+    }
 
-		if (!target) {
-			new NotificationBuilder()
-				.withMessage("mirrord running targetless")
-				.withDisableAction("promptTargetless")
-				.info();
-		}
-	}
+    if (!target) {
+      new NotificationBuilder()
+        .withMessage("mirrord running targetless")
+        .withDisableAction("promptTargetless")
+        .info();
+    }
+  }
 
-	if (config.type === "go") {
-		config.env["MIRRORD_SKIP_PROCESSES"] = "dlv;debugserver;compile;go;asm;cgo;link;git;gcc;as;ld;collect2;cc1";
-	} else if (config.type === "python") {
-		config.env["MIRRORD_DETECT_DEBUGGER_PORT"] = "debugpy";
-	} else if (config.type === "java") {
-		config.env["MIRRORD_DETECT_DEBUGGER_PORT"] = "javaagent";
-	}
+  if (config.type === "go") {
+    config.env["MIRRORD_SKIP_PROCESSES"] = "dlv;debugserver;compile;go;asm;cgo;link;git;gcc;as;ld;collect2;cc1";
+  } else if (config.type === "python") {
+    config.env["MIRRORD_DETECT_DEBUGGER_PORT"] = "debugpy";
+  } else if (config.type === "java") {
+    config.env["MIRRORD_DETECT_DEBUGGER_PORT"] = "javaagent";
+  }
 
-	// Add a fixed range of ports that VS Code uses for debugging.
-	// TODO: find a way to use MIRRORD_DETECT_DEBUGGER_PORT for other debuggers.
-	config.env["MIRRORD_IGNORE_DEBUGGER_PORTS"] = "45000-65535";
+  // Add a fixed range of ports that VS Code uses for debugging.
+  // TODO: find a way to use MIRRORD_DETECT_DEBUGGER_PORT for other debuggers.
+  config.env["MIRRORD_IGNORE_DEBUGGER_PORTS"] = "45000-65535";
 
-	let isMac = platform() === "darwin";
+  let isMac = platform() === "darwin";
 
-	let [executableFieldName, executable] = isMac ? getFieldAndExecutable(config) : [null, null];
+  let [executableFieldName, executable] = isMac ? getFieldAndExecutable(config) : [null, null];
 
-	let executionInfo;
-	try {
-		executionInfo = await mirrordApi.binaryExecute(target, configPath?.path || null, executable, config.env);
-	} catch (err) {
-		mirrordFailure(`mirrord preparation failed: ${err}`);
-		return null;
-	}
+  let executionInfo;
+  try {
+    executionInfo = await mirrordApi.binaryExecute(target, configPath?.path || null, executable, config.env);
+  } catch (err) {
+    mirrordFailure(`mirrord preparation failed: ${err}`);
+    return null;
+  }
 
-	if (isMac) {
-		changeConfigForSip(config, executableFieldName as string, executionInfo);
-	}
+  if (isMac) {
+    changeConfigForSip(config, executableFieldName as string, executionInfo);
+  }
 
-	let env = executionInfo?.env;
-	config.env = Object.assign({}, config.env, Object.fromEntries(env));
+  let env = executionInfo?.env;
+  config.env = Object.assign({}, config.env, Object.fromEntries(env));
 
-	config.env["__MIRRORD_EXT_INJECTED"] = 'true';
+  config.env["__MIRRORD_EXT_INJECTED"] = 'true';
 
-	return config;
+  return config;
 }
 
 /**
 * We implement the `resolveDebugConfiguration` that comes with vscode variables resolved already.
 */
 export class ConfigurationProvider implements vscode.DebugConfigurationProvider {
-	async resolveDebugConfigurationWithSubstitutedVariables(
-		folder: vscode.WorkspaceFolder | undefined,
-		config: vscode.DebugConfiguration,
-		_token: vscode.CancellationToken): Promise<vscode.DebugConfiguration | null | undefined> {
-		try {
-			return await main(folder, config, _token);
-		} catch (fail) {
-			console.error(`Something went wrong in the extension: ${fail}`);
-			new NotificationBuilder()
-				.withMessage(`Something went wrong: ${fail}`)
-				.error();
-		}
-	}
+  async resolveDebugConfigurationWithSubstitutedVariables(
+    folder: vscode.WorkspaceFolder | undefined,
+    config: vscode.DebugConfiguration,
+    _token: vscode.CancellationToken): Promise<vscode.DebugConfiguration | null | undefined> {
+    try {
+      return await main(folder, config, _token);
+    } catch (fail) {
+      console.error(`Something went wrong in the extension: ${fail}`);
+      new NotificationBuilder()
+        .withMessage(`Something went wrong: ${fail}`)
+        .error();
+    }
+  }
 }

--- a/src/tests/e2e.ts
+++ b/src/tests/e2e.ts
@@ -15,122 +15,122 @@ const podToSelect = process.env.POD_TO_SELECT;
  * - Send traffic to the pod
  * - Tests successfully exit if "GET: Request completed" is found in the terminal
 */
-describe("mirrord sample flow test", function () {
+describe("mirrord sample flow test", function() {
 
-    this.timeout("6 minutes"); // --> mocha tests timeout
-    this.bail(true); // --> stop tests on first failure
+  this.timeout("6 minutes"); // --> mocha tests timeout
+  this.bail(true); // --> stop tests on first failure
 
-    let browser: VSBrowser;
+  let browser: VSBrowser;
 
-    const testWorkspace = join(__dirname, '../../test-workspace');
-    const fileName = "app_flask.py";
-    const defaultTimeout = 10000; // = 10 seconds
+  const testWorkspace = join(__dirname, '../../test-workspace');
+  const fileName = "app_flask.py";
+  const defaultTimeout = 10000; // = 10 seconds
 
-    before(async function () {
-        console.log("podToSelect: " + podToSelect);
-        console.log("kubeService: " + kubeService);
+  before(async function() {
+    console.log("podToSelect: " + podToSelect);
+    console.log("kubeService: " + kubeService);
 
-        expect(podToSelect).to.not.be.undefined;
-        expect(kubeService).to.not.be.undefined;
+    expect(podToSelect).to.not.be.undefined;
+    expect(kubeService).to.not.be.undefined;
 
-        browser = VSBrowser.instance;
-        
-        await browser.openResources(testWorkspace, join(testWorkspace, fileName));
-        await browser.waitForWorkbench();
+    browser = VSBrowser.instance;
 
-        const ew = new EditorView();
+    await browser.openResources(testWorkspace, join(testWorkspace, fileName));
+    await browser.waitForWorkbench();
+
+    const ew = new EditorView();
+    try {
+      await ew.closeEditor('Welcome');
+    } catch (error) {
+      console.log("Welcome page is not displayed" + error);
+      // continue - Welcome page is not displayed
+    }
+    await ew.openEditor('app_flask.py');
+  });
+
+  it("enable mirrord button", async function() {
+    const statusBar = new StatusBar();
+
+    await browser.driver.wait(async () => {
+      return await statusBar.isDisplayed();
+    });
+
+    // vscode refreshes the status bar on load and there is no deterministic way but to retry to click on 
+    // the mirrord button after an interval
+    await browser.driver.wait(async () => {
+      let retries = 0;
+      while (retries < 3) {
         try {
-            await ew.closeEditor('Welcome');
-        } catch (error) {
-            console.log("Welcome page is not displayed" + error)
-            // continue - Welcome page is not displayed
+          for (let button of await statusBar.getItems()) {
+            if ((await button.getText()).startsWith('mirrord')) {
+              await button.click();
+              return true;
+            }
+          }
+        } catch (e) {
+          if (e instanceof Error && e.name === 'StaleElementReferenceError') {
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            retries++;
+          } else {
+            throw e;
+          }
         }
-        await ew.openEditor('app_flask.py');
-    });
+      }
+      throw new Error('Failed to click the button after multiple attempts');
+    }, defaultTimeout, "mirrord `enable` button not found -- timed out");
+  });
 
-    it("enable mirrord button", async function () {
-        const statusBar = new StatusBar();
+  it("select pod from quickpick", async function() {
+    await startDebugging();
+    const inputBox = await InputBox.create(defaultTimeout * 2);
+    // assertion that podToSelect is not undefined is done in "before" block   
+    await browser.driver.wait(async () => {
+      if (!await inputBox.isDisplayed()) {
+        return false;
+      }
 
-        await browser.driver.wait(async () => {
-            return await statusBar.isDisplayed();
-        });
+      for (const pick of await inputBox.getQuickPicks()) {
+        let label = await pick.getLabel();
 
-        // vscode refreshes the status bar on load and there is no deterministic way but to retry to click on 
-        // the mirrord button after an interval
-        await browser.driver.wait(async () => {
-            let retries = 0;
-            while (retries < 3) {
-                try {
-                    for (let button of await statusBar.getItems()) {
-                        if ((await button.getText()).startsWith('mirrord')) {
-                            await button.click();
-                            return true;
-                        }
-                    }
-                } catch (e) {
-                    if (e instanceof Error && e.name === 'StaleElementReferenceError') {
-                        await new Promise(resolve => setTimeout(resolve, 1000));
-                        retries++;
-                    } else {
-                        throw e;
-                    }
-                }
-            }
-            throw new Error('Failed to click the button after multiple attempts');
-        }, defaultTimeout, "mirrord `enable` button not found -- timed out");
-    });
+        if (label === podToSelect) {
+          return true;
+        }
+        // to pick up the podToSelect, we need to select the "Show Pods" 
+        // from quickpick as pods are not displayed first
+        if (label === "Show Pods") {
+          await pick.select();
+        }
+      }
 
-    it("select pod from quickpick", async function () {
-        await startDebugging();
-        const inputBox = await InputBox.create(defaultTimeout * 2);
-        // assertion that podToSelect is not undefined is done in "before" block   
-        await browser.driver.wait(async () => {
-            if (!await inputBox.isDisplayed()) {
-                return false;
-            }
+      return false;
+    }, defaultTimeout * 2, "quickPick not found -- timed out");
 
-            for (const pick of await inputBox.getQuickPicks()) {
-                let label = await pick.getLabel();
+    await inputBox.selectQuickPick(podToSelect!);
+  });
 
-                if (label === podToSelect) {
-                    return true;
-                }
-                // to pick up the podToSelect, we need to select the "Show Pods" 
-                // from quickpick as pods are not displayed first
-                if (label === "Show Pods") {
-                    await pick.select();
-                }
-            }
-
-            return false;
-        }, defaultTimeout * 2, "quickPick not found -- timed out");
-
-        await inputBox.selectQuickPick(podToSelect!);
-    });
-
-    it("wait for process to write to terminal", async function () {
-        const debugToolbar = await DebugToolbar.create(2 * defaultTimeout);
-        const panel = new BottomBarPanel();
-        await browser.driver.wait(async () => {
-            return await debugToolbar.isDisplayed();
-        }, 2 * defaultTimeout, "debug toolbar not found -- timed out");
+  it("wait for process to write to terminal", async function() {
+    const debugToolbar = await DebugToolbar.create(2 * defaultTimeout);
+    const panel = new BottomBarPanel();
+    await browser.driver.wait(async () => {
+      return await debugToolbar.isDisplayed();
+    }, 2 * defaultTimeout, "debug toolbar not found -- timed out");
 
 
-        let terminal = await panel.openTerminalView();
+    let terminal = await panel.openTerminalView();
 
-        await browser.driver.wait(async () => {
-            const text = await terminal.getText();
-            return await terminal.isDisplayed() && text.includes("Press CTRL+C to quit");
-        }, 2 * defaultTimeout, "terminal text not found -- timed out");
+    await browser.driver.wait(async () => {
+      const text = await terminal.getText();
+      return await terminal.isDisplayed() && text.includes("Press CTRL+C to quit");
+    }, 2 * defaultTimeout, "terminal text not found -- timed out");
 
-        await sendTrafficToPod();
+    await sendTrafficToPod();
 
-        await browser.driver.wait(async () => {
-            const text = await terminal.getText();
-            return text.includes("GET: Request completed");
-        }, defaultTimeout, "terminal text not found -- timed out");
+    await browser.driver.wait(async () => {
+      const text = await terminal.getText();
+      return text.includes("GET: Request completed");
+    }, defaultTimeout, "terminal text not found -- timed out");
 
-    });
+  });
 });
 
 
@@ -138,9 +138,9 @@ describe("mirrord sample flow test", function () {
  * sends a GET request to the pod's nodePort
  */
 async function sendTrafficToPod() {
-    const response = await get(kubeService!!);
-    expect(response.status).to.equal(200);
-    expect(response.data).to.equal("OK - GET: Request completed\n");
+  const response = await get(kubeService!!);
+  expect(response.status).to.equal(200);
+  expect(response.data).to.equal("OK - GET: Request completed\n");
 }
 
 /**
@@ -148,9 +148,9 @@ async function sendTrafficToPod() {
  * debugging starts from the "Run and Debug" button in the activity bar 
 */
 async function startDebugging(configurationFile: string = "Python: Current File") {
-    const activityBar = await new ActivityBar().getViewControl("Run and Debug");
-    expect(activityBar).to.not.be.undefined;
-    const debugView = await activityBar?.openView() as DebugView;
-    await debugView.selectLaunchConfiguration(configurationFile);
-    await debugView.start();
+  const activityBar = await new ActivityBar().getViewControl("Run and Debug");
+  expect(activityBar).to.not.be.undefined;
+  const debugView = await activityBar?.openView() as DebugView;
+  await debugView.selectLaunchConfiguration(configurationFile);
+  await debugView.start();
 }


### PR DESCRIPTION
- Issue: #70 

Passes the `launch.json` `env` section to `mirrord verify-config`, and `mirrord`, resolving config options that were set as env vars.

- intellij PR: [#181](https://github.com/metalbear-co/mirrord-intellij/pull/181)

### For the reviewer:

Think we're not using any standard formatter for this, so huge part of the diff is just indentation changes.

The [src/tests/e2e.ts](https://github.com/metalbear-co/mirrord-vscode/pull/74/files#diff-b43d278da30fffad8eb324e1f1165f5e2ae4ecddd858801a51e0ce3e08c7f65c) file was only changed to add a `;` that was missing.

Most of the changes have to do with `configEnv` or `config.env`.