### PR TITLE
Remove quotes around GITHUB_PATH in e2e

### DIFF
--- a/.github/workflows/reusable_e2e.yaml
+++ b/.github/workflows/reusable_e2e.yaml
@@ -70,7 +70,7 @@ jobs:
         if: ${{ inputs.mirrord_release_branch }}
         run: |
           chmod u+x mirrord
-          echo "${GITHUB_WORKSPACE}" >> "$GITHUB_PATH"
+          echo "${GITHUB_WORKSPACE}" >> $GITHUB_PATH
 
       - name: get the latest mirrord binary
         if: ${{ !inputs.mirrord_release_branch }}

--- a/changelog.d/+remove-quotes.internal.md
+++ b/changelog.d/+remove-quotes.internal.md
@@ -1,0 +1,1 @@
+Remove quotes around GITHUB_PATH in e2e


### PR DESCRIPTION
As pointed out by @t4lz 

```
Remove the quotation marks around $GITHUB_PATH.
Usages across GitHub without quotes: [https://github.com/search?q="echo+%5C"%24%7BGITHUB_WORKSPACE%7D%5C"+>>+%24GITHUB_PATH"&type=code](https://github.com/search?q=%22echo+%5C%22%24%7BGITHUB_WORKSPACE%7D%5C%22+%3E%3E+%24GITHUB_PATH%22&type=code) (22 files)
With quotes: [https://github.com/search?q="echo+%5C"%24%7BGITHUB_WORKSPACE%7D%5C"+>>+%5C"%24GITHUB_PATH%5C""&type=code](https://github.com/search?q=%22echo+%5C%22%24%7BGITHUB_WORKSPACE%7D%5C%22+%3E%3E+%5C%22%24GITHUB_PATH%5C%22%22&type=code) (only us)
```