### PR TITLE
Prevent error on undefined node-terminal command

### DIFF
--- a/changelog.d/+node-terminal-without-command.fixed.md
+++ b/changelog.d/+node-terminal-without-command.fixed.md
@@ -1,0 +1,1 @@
+Prevent mirrord from throwing an error when running with `node-terminal` configuration type with missing `command` field.

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -60,7 +60,7 @@ function changeConfigForSip(config: vscode.DebugConfiguration, executableFieldNa
 		// Run the command in a SIP-patched shell, that way everything that runs in the original command will be SIP-patched
 		// on runtime.
 		config[executableFieldName] = `echo '${escapedCommand}' | ${DYLD_ENV_VAR_NAME}=${libraryPath} ${sh} -is`;
-	} else if (executionInfo.patchedPath != null) {
+	} else if (executionInfo.patchedPath) {
 		config[executableFieldName] = executionInfo.patchedPath!;
 	}
 }

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -46,7 +46,7 @@ function getFieldAndExecutable(config: vscode.DebugConfiguration): [keyof vscode
 function changeConfigForSip(config: vscode.DebugConfiguration, executableFieldName: string, executionInfo: MirrordExecution) {
 	if (config.type === "node-terminal") {
 		const command = config[executableFieldName];
-		if (command === null) {
+		if (command == null) {
 			return;
 		}
 

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -60,7 +60,7 @@ function changeConfigForSip(config: vscode.DebugConfiguration, executableFieldNa
 		// Run the command in a SIP-patched shell, that way everything that runs in the original command will be SIP-patched
 		// on runtime.
 		config[executableFieldName] = `echo '${escapedCommand}' | ${DYLD_ENV_VAR_NAME}=${libraryPath} ${sh} -is`;
-	} else if (executionInfo.patchedPath !== null) {
+	} else if (executionInfo.patchedPath != null) {
 		config[executableFieldName] = executionInfo.patchedPath!;
 	}
 }

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -46,7 +46,7 @@ function getFieldAndExecutable(config: vscode.DebugConfiguration): [keyof vscode
 function changeConfigForSip(config: vscode.DebugConfiguration, executableFieldName: string, executionInfo: MirrordExecution) {
 	if (config.type === "node-terminal") {
 		const command = config[executableFieldName];
-		if (command == null) {
+		if (!command) {
 			return;
 		}
 


### PR DESCRIPTION
We check strictly for `null`, and then use the `command` field as if it's a valid object, so if it's `undefined` we would get an error.