### PR TITLE
Reject `attach` launch configurations

### DIFF
--- a/changelog.d/+reject-attach.fixed.md
+++ b/changelog.d/+reject-attach.fixed.md
@@ -1,0 +1,1 @@
+mirrord now shows an error notification when the user tries to use it with an `attach` launch configuration.

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -95,6 +95,13 @@ async function main(
 		return config;
 	}
 
+	if (config.request === "attach") {
+		new NotificationBuilder()
+			.withMessage("mirrord cannot be used with `attach` launch configurations")
+			.error();
+		return null;
+	}
+
 	// For some reason resolveDebugConfiguration runs twice for Node projects. __parentId is populated.
 	if (config.__parentId || config.env?.["__MIRRORD_EXT_INJECTED"] === 'true') {
 		return config;

--- a/src/tests/e2e.ts
+++ b/src/tests/e2e.ts
@@ -42,7 +42,7 @@ describe("mirrord sample flow test", function () {
         try {
             await ew.closeEditor('Welcome');
         } catch (error) {
-            console.log("Welcome page is not displayed" + error)
+            console.log("Welcome page is not displayed" + error);
             // continue - Welcome page is not displayed
         }
         await ew.openEditor('app_flask.py');


### PR DESCRIPTION
Running `attach` launch configurations with mirrord doesn't have much sense and results in weird errors. Now, when the user tries to use mirrord with such config, the extension shows an error and the IDE jumps to `launch.json` file