### PR TITLE
Write toggle status to disk

### DIFF
--- a/src/status.ts
+++ b/src/status.ts
@@ -89,6 +89,14 @@ export class MirrordStatus {
 
         this.enabled = !this.enabled;
 
+        let filePath = vscode.Uri.joinPath(globalContext.globalStorageUri, 'toggleStatus.json');
+        let obj = { enabled: this.enabled };
+        let data = new TextEncoder().encode(JSON.stringify(obj));
+
+        vscode.workspace.fs.writeFile(filePath, data).then(() => {}, err => {
+            console.error('Error writing file:', err);
+        });
+
         this.draw();
     }
 


### PR DESCRIPTION
I want to launch a task before the start of a debug session using `preLaunchTask`, thought, I want to do this only when mirrord toggle is enabled.

Writing toggle status to a file allows me to read it's content in `preLaunchTask` script of choice and to execute the relevant logic.