### PR TITLE
support debugpy on macos

### DIFF
--- a/changelog.d/132.added.md
+++ b/changelog.d/132.added.md
@@ -1,0 +1,1 @@
+Support for debugpy current file debugging on macOS.

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -27,6 +27,7 @@ function getFieldAndExecutable(config: vscode.DebugConfiguration): [keyof vscode
       // for SIP, so we pass the shell to the mirrod CLI.
       return ["command", vscode.env.shell];
     }
+    case "debugpy":
     case "python": {
       if ("python" in config) {
         return ["python", config["python"]];

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -37,6 +37,11 @@ function getFieldAndExecutable(config: vscode.DebugConfiguration): [keyof vscode
       return ["pythonPath", config["pythonPath"]];
     }
     default: {
+      if ("python" in config) {
+        // We don't know that config type yet, but the config has the field "python", so we assume that's the path of the 
+        // python binary and we patch that.
+        return ["python", config["python"]];
+      }
       return ["program", config["program"]];
     }
   }

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -7,6 +7,7 @@ import { getMirrordBinary } from './binaryManager';
 import { platform } from 'node:os';
 import { NotificationBuilder } from './notification';
 import { setOperatorUsed } from './mirrordForTeams';
+import fs from 'fs';
 
 const DYLD_ENV_VAR_NAME = "DYLD_INSERT_LIBRARIES";
 
@@ -37,9 +38,9 @@ function getFieldAndExecutable(config: vscode.DebugConfiguration): [keyof vscode
       return ["pythonPath", config["pythonPath"]];
     }
     default: {
-      if ("python" in config) {
-        // We don't know that config type yet, but the config has the field "python", so we assume that's the path of the 
-        // python binary and we patch that.
+      if ("python" in config && fs.existsSync(config["python"])) {
+        // We don't know that config type yet, but the config has the field "python" that contains a path that exists,
+        // so we assume that's the path of the python binary and we patch that.
         return ["python", config["python"]];
       }
       return ["program", config["program"]];


### PR DESCRIPTION
Closes #132.

- Add `debugpy` to known config types. No need for new logic - same old `python` logic works.
- From now on, if there is a config type we don't know, but it has the field `python`, we use that field, instead of `program`. If we had this before we would have supported debugpy without adding it explicitly. On the other hand, it could theoretically break things: hypothetical scenario - users are using some exotic launch configuration that has the binary under `program` but also has a `python` field, but `program` is the one that should be SIPed, then it wouldn't work anymore. I think it's unlikely that this exists so the change is worth it, let me know if you disagree.