### PR TITLE
Do not sort targets from `mirrord ls`, they already come in a neat order.

### DIFF
--- a/changelog.d/147.changed.md
+++ b/changelog.d/147.changed.md
@@ -1,0 +1,1 @@
+Do not sort targets when showing them to the user, they come pre-sorted from mirrord ls.

--- a/src/api.ts
+++ b/src/api.ts
@@ -87,7 +87,7 @@ interface IdeMessage {
  * Replaces the "plugin" platform query parameter in the given link with "vscode"
  */
 function changeQueryParam(link: string): string {
-  return link.replace("utm_medium=cli", "utm_medium=vscode").replace("utm_medium=plugin", "utm_medium=vscode")
+  return link.replace("utm_medium=cli", "utm_medium=vscode").replace("utm_medium=plugin", "utm_medium=vscode");
 }
 
 /**

--- a/src/api.ts
+++ b/src/api.ts
@@ -343,7 +343,7 @@ export class MirrordAPI {
 
   /**
   * Uses `mirrord ls` to get a list of all targets.
-  * Targets are sorted, with an exception of the last used target being the first on the list.
+  * Targets come sorted, with an exception of the last used target being the first on the list.
   */
   async listTargets(configPath: string | null | undefined): Promise<Targets> {
     const args = ['ls'];
@@ -354,7 +354,6 @@ export class MirrordAPI {
     const stdout = await this.exec(args, {});
 
     const targets: string[] = JSON.parse(stdout);
-    targets.sort();
 
     let lastTarget: string | undefined = globalContext.workspaceState.get(LAST_TARGET_KEY)
       || globalContext.globalState.get(LAST_TARGET_KEY);


### PR DESCRIPTION
Closes #147 

Related PR: https://github.com/metalbear-co/mirrord/pull/2732


Now the targets come sorted from `mirrord ls` itself, we just need to add the last one used at the top, and not sort the whole list.