### PR TITLE
Fix timeout on mirrord --version that can linger forever

### DIFF
--- a/changelog.d/+corrupt-binary-bug.fixed.md
+++ b/changelog.d/+corrupt-binary-bug.fixed.md
@@ -1,0 +1,1 @@
+Timeout on mirrord --version that can linger forever if binary is corrupt


### PR DESCRIPTION
Fix timeout on mirrord --version that can linger forever if binary is corrupt
