### PR TITLE
win-38 ⊹ IDE: attach support 2: the electric boogaloo

### DIFF
--- a/changelog.d/+windows-extension-support.added.md
+++ b/changelog.d/+windows-extension-support.added.md
@@ -1,0 +1,1 @@
+Implemented Windows support for extension.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 				"@types/which": "^3.0.0",
 				"@typescript-eslint/eslint-plugin": "^8.0.0",
 				"@typescript-eslint/parser": "^8.0.0",
+				"@vscode/debugprotocol": "^1.68.0",
 				"@vscode/vsce": "^2.9.2",
 				"chai": "^5.2.0",
 				"esbuild": "^0.25.1",
@@ -1424,6 +1425,13 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			}
+		},
+		"node_modules/@vscode/debugprotocol": {
+			"version": "1.68.0",
+			"resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.68.0.tgz",
+			"integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@vscode/vsce": {
 			"version": "2.32.0",

--- a/package.json
+++ b/package.json
@@ -285,6 +285,7 @@
 		"@types/which": "^3.0.0",
 		"@typescript-eslint/eslint-plugin": "^8.0.0",
 		"@typescript-eslint/parser": "^8.0.0",
+		"@vscode/debugprotocol": "^1.68.0",
 		"@vscode/vsce": "^2.9.2",
 		"chai": "^5.2.0",
 		"esbuild": "^0.25.1",

--- a/src/api.ts
+++ b/src/api.ts
@@ -425,6 +425,14 @@ export class MirrordAPI {
   }
 
   /**
+  * Attaches the mirrord layer to an already-running process by PID.
+  * Used on Windows where LD_PRELOAD is not available.
+  */
+  async attach(pid: number, configEnv: EnvVars): Promise<void> {
+    await this.exec(["attach", pid.toString()], configEnv, 30000);
+  }
+
+  /**
   * Runs the extension execute sequence, creating agent and gathering execution runtime while also
   * setting env vars, both from system, and from `launch.json` (`configEnv`).
   *

--- a/src/api.ts
+++ b/src/api.ts
@@ -414,7 +414,14 @@ export class MirrordAPI {
   */
   async verifyConfig(configPath: vscode.Uri | null, configEnv: EnvVars): Promise<VerifiedConfig | undefined> {
     if (configPath) {
-      const args = ['verify-config', '--ide', `${configPath.path}`];
+      // NOTE: `fsPath`/`_fsPath` is correct, whereas `path` is incorrect,
+      // for cross-platform support. e.g.:
+      //
+      // _fsPath = 'c:\\dev\\latest-ide-test'
+      // path = '/c:/dev/latest-ide-test'
+      //
+      // See the documentation for more information.
+      const args = ['verify-config', '--ide', `${configPath.fsPath}`];
       const stdout = await this.exec(args, configEnv);
 
       const verifiedConfig: VerifiedConfig = JSON.parse(stdout);
@@ -683,11 +690,11 @@ function tickNewsletterCounter() {
 
   if (msg) {
     new NotificationBuilder()
-    .withMessage(msg)
-    .withGenericAction("Subscribe to the mirrord newsletter", async () => {
-      vscode.commands.executeCommand(MirrordStatus.newsletterCommandId);
-    })
-    .withDisableAction('promptNewsletter')
-    .info();
+      .withMessage(msg)
+      .withGenericAction("Subscribe to the mirrord newsletter", async () => {
+        vscode.commands.executeCommand(MirrordStatus.newsletterCommandId);
+      })
+      .withDisableAction('promptNewsletter')
+      .info();
   }
 }

--- a/src/binaryManager.ts
+++ b/src/binaryManager.ts
@@ -15,6 +15,10 @@ const mirrordBinaryEndpoint = 'https://version.mirrord.dev/v1/version';
 // const binaryCheckInterval = 1000 * 60 * 3;
 const baseDownloadUri = 'https://github.com/metalbear-co/mirrord/releases/download';
 
+// When true, auto-update is ignored and only local/configured binaries are used.
+// Useful during development when working with a locally-built mirrord binary.
+const IGNORE_AUTOUPDATE_SETTINGS = true;
+
 function getExtensionMirrordPath(): Uri {
     return Utils.joinPath(globalContext.globalStorageUri, 'mirrord');
 }
@@ -134,7 +138,10 @@ export async function getMirrordBinary(background: boolean): Promise<string | nu
         return configured;
     }
 
-    const autoUpdateConfigured = vscode.workspace.getConfiguration().get("mirrord.autoUpdate");
+    let autoUpdateConfigured = vscode.workspace.getConfiguration().get("mirrord.autoUpdate");
+    if (IGNORE_AUTOUPDATE_SETTINGS === true) {
+        autoUpdateConfigured = false;
+    }
 
     // values for `mirrord.autoUpdate` can be:
     // - true or empty string: auto-update is enabled

--- a/src/binaryManager.ts
+++ b/src/binaryManager.ts
@@ -15,10 +15,6 @@ const mirrordBinaryEndpoint = 'https://version.mirrord.dev/v1/version';
 // const binaryCheckInterval = 1000 * 60 * 3;
 const baseDownloadUri = 'https://github.com/metalbear-co/mirrord/releases/download';
 
-// When true, auto-update is ignored and only local/configured binaries are used.
-// Useful during development when working with a locally-built mirrord binary.
-const IGNORE_AUTOUPDATE_SETTINGS = true;
-
 function getExtensionMirrordPath(): Uri {
     return Utils.joinPath(globalContext.globalStorageUri, 'mirrord');
 }
@@ -138,10 +134,7 @@ export async function getMirrordBinary(background: boolean): Promise<string | nu
         return configured;
     }
 
-    let autoUpdateConfigured = vscode.workspace.getConfiguration().get("mirrord.autoUpdate");
-    if (IGNORE_AUTOUPDATE_SETTINGS === true) {
-        autoUpdateConfigured = false;
-    }
+    const autoUpdateConfigured = vscode.workspace.getConfiguration().get("mirrord.autoUpdate");
 
     // values for `mirrord.autoUpdate` can be:
     // - true or empty string: auto-update is enabled

--- a/src/config.ts
+++ b/src/config.ts
@@ -97,12 +97,12 @@ export class MirrordConfigManager {
     this.fileListeners = [];
 
     this.fileListeners.push(vscode.workspace.onDidDeleteFiles(async event => {
-      const activePath = this.active?.path;
+      const activePath = this.active?.fsPath;
       if (!activePath) {
         return;
       }
 
-      const deleted = event.files.find(file => activePath.startsWith(file.path));
+      const deleted = event.files.find(file => activePath.startsWith(file.fsPath));
 
       if (deleted) {
         new NotificationBuilder()
@@ -117,14 +117,14 @@ export class MirrordConfigManager {
     }));
 
     this.fileListeners.push(vscode.workspace.onDidRenameFiles(async event => {
-      const activePath = this.active?.path;
+      const activePath = this.active?.fsPath;
       if (!activePath) {
         return;
       }
 
-      const moved = event.files.find(file => activePath.startsWith(file.oldUri.path));
+      const moved = event.files.find(file => activePath.startsWith(file.oldUri.fsPath));
       if (moved) {
-        const newPath = activePath.replace(moved.oldUri.path, moved.newUri.path);
+        const newPath = activePath.replace(moved.oldUri.fsPath, moved.newUri.fsPath);
         const newUri = vscode.Uri.parse(`file://${newPath}`);
         new NotificationBuilder()
           .withMessage(`moved active mirrord configuration to ${vscode.workspace.asRelativePath(newUri)}`)
@@ -208,7 +208,7 @@ export class MirrordConfigManager {
   private static async getDefaultConfig(folder: vscode.WorkspaceFolder): Promise<vscode.Uri | undefined> {
     const pattern = new vscode.RelativePattern(folder, ".mirrord/*mirrord.{toml,json,yml,yaml}");
     const files = await vscode.workspace.findFiles(pattern);
-    files.sort((f1, f2) => f1.path.localeCompare(f2.path));
+    files.sort((f1, f2) => f1.fsPath.localeCompare(f2.fsPath));
     return files[0];
   }
 
@@ -237,7 +237,7 @@ export class MirrordConfigManager {
 
     // Active config first.
     if (this.active) {
-      options.set(`(active) ${vscode.workspace.asRelativePath(this.active.path)}`, this.active);
+      options.set(`(active) ${vscode.workspace.asRelativePath(this.active.fsPath)}`, this.active);
     }
 
     // Then all configs found in launch configurations across the workspace.
@@ -291,7 +291,7 @@ export class MirrordConfigManager {
       await MirrordConfigManager.createDefaultConfig(vscode.workspace.getWorkspaceFolder(path)!);
     }
 
-    const doc = await vscode.workspace.openTextDocument(path.path);
+    const doc = await vscode.workspace.openTextDocument(path.fsPath);
     vscode.window.showTextDocument(doc);
   }
 

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -171,7 +171,7 @@ async function main(
     const supportedTypes = TargetQuickPick.getSupportedTargetTypes();
     const getTargets = async (namespace?: string) => {
       return mirrordApi.listTargets(
-        configPath?.path,
+        configPath?.fsPath,
         config.env,
         supportedTypes,
         namespace,
@@ -216,10 +216,10 @@ async function main(
   try {
     executionInfo = await mirrordApi.binaryExecute(
       quickPickSelection,
-      configPath?.path || null,
+      configPath?.fsPath || null,
       executable,
       config.env,
-      folder?.uri.path,
+      folder?.uri.fsPath,
     );
   } catch (err) {
     mirrordFailure(`mirrord preparation failed: ${err}`);
@@ -269,8 +269,7 @@ async function main(
  * We implement the `resolveDebugConfiguration` that comes with vscode variables resolved already.
  */
 export class ConfigurationProvider
-  implements vscode.DebugConfigurationProvider
-{
+  implements vscode.DebugConfigurationProvider {
   async resolveDebugConfigurationWithSubstitutedVariables(
     folder: vscode.WorkspaceFolder | undefined,
     config: vscode.DebugConfiguration,

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -37,13 +37,17 @@ export const pendingAttaches: PendingAttach[] = [];
  * Most debuggers use `stopOnEntry`, but C# (coreclr/clr) uses `stopAtEntry`.
  */
 function getStopOnEntryProperty(debugType: string): string {
+  let prop: string;
   switch (debugType) {
     case "coreclr":
     case "clr":
-      return "stopAtEntry";
+      prop = "stopAtEntry";
+      break;
     default:
-      return "stopOnEntry";
+      prop = "stopOnEntry";
+      break;
   }
+  return prop;
 }
 
 /// Get the name of the field that holds the exectuable in a debug configuration of the given type,
@@ -254,12 +258,13 @@ async function main(
 
     config[stopProp] = true;
 
-    pendingAttaches.push({
+    const pendingEntry: PendingAttach = {
       cliPath,
       configEnv: { ...config.env },
       stopOnEntryProperty: stopProp,
       userHadStopOnEntry,
-    });
+    };
+    pendingAttaches.push(pendingEntry);
   }
 
   return config;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
-import { ConfigurationProvider } from './debugger';
+import { ConfigurationProvider, pendingAttaches } from './debugger';
 import { MirrordStatus } from './status';
 import { getMirrordBinary } from './binaryManager';
+import { MirrordAPI } from './api';
 import Logger from './logger';
 
 export let globalContext: vscode.ExtensionContext;
@@ -16,6 +17,87 @@ export async function activate(context: vscode.ExtensionContext) {
 	const enabled = vscode.workspace.getConfiguration().get<boolean | null>("mirrord.enabledByDefault");
 	context.workspaceState.update('enabled', enabled);
 	vscode.debug.registerDebugConfigurationProvider('*', new ConfigurationProvider(), 2);
+
+	// On Windows, register a DAP tracker to catch the process start event
+	// and inject the mirrord layer via `mirrord attach <PID>`.
+	if (process.platform === "win32") {
+		vscode.debug.registerDebugAdapterTrackerFactory('*', {
+			createDebugAdapterTracker(session: vscode.DebugSession) {
+				if (pendingAttaches.length === 0) {
+					return undefined;
+				}
+
+				const pending = pendingAttaches.shift()!;
+
+				// Closure variable shared across `onDidSendMessage` invocations for
+				// this debug session. Set once when we receive the DAP 'process' event,
+				// then awaited by the 'stopped' handler to ensure DLL injection is
+				// complete before resuming execution.
+				let attachPromise: Promise<boolean> | null = null;
+
+				return {
+					// This is untyped for now.
+					onDidSendMessage: async (message: any) => {
+						/* ────────────────────────────────────────────────────────────────────────── */
+
+						// This code heavily depends on the DAP specification, please refer to
+						// https://microsoft.github.io/debug-adapter-protocol//specification.html
+						// if you are confused about any usage in the untyped code.
+
+						/* ────────────────────────────────────────────────────────────────────────── */
+
+						// DAP 'process' event carries `systemProcessId`.
+						// This fires once when the debug adapter spawns the target process.
+						// We inject the mirrord layer DLL into it here.
+						if (message.type === 'event' && message.event === 'process') {
+							const pid = message.body?.systemProcessId;
+							if (pid && !attachPromise) {
+								Logger.info(`mirrord: attaching to process ${pid}`);
+								attachPromise = (async () => {
+									try {
+										const api = new MirrordAPI(pending.cliPath);
+										await api.attach(pid, pending.configEnv);
+										Logger.info(`mirrord: layer injected into process ${pid}`);
+										return true;
+									} catch (err) {
+										const errorMsg = err instanceof Error ? err.message : String(err);
+										Logger.error(`mirrord: attach failed: ${errorMsg}`);
+										vscode.window.showErrorMessage(`mirrord attach failed: ${errorMsg}`);
+										return false;
+									}
+								})();
+							}
+						}
+
+						// DAP 'stopped' event with reason 'entry' fires when the debugger
+						// pauses at entry due to stopOnEntry/stopAtEntry we set.
+						// This arrives in a later `onDidSendMessage` call than 'process'.
+						// We await the closure's `attachPromise` to ensure DLL injection
+						// finished, then resume if the user didn't originally request
+						// stop-on-entry.
+						if (!pending.userHadStopOnEntry
+							&& message.type === 'event' && message.event === 'stopped'
+							&& message.body?.reason === 'entry'
+							&& attachPromise) {
+							const success = await attachPromise;
+							if (success) {
+								const threadId = message.body?.threadId;
+								if (threadId !== undefined) {
+									Logger.info(`mirrord: resuming after forced stop-on-entry`);
+									try {
+										await session.customRequest('continue', { threadId });
+									} catch (err) {
+										const errorMsg = err instanceof Error ? err.message : String(err);
+										Logger.error(`mirrord: failed to resume: ${errorMsg}`);
+									}
+								}
+							}
+						}
+					},
+				};
+			}
+		});
+	}
 
 	// Start mirrord binary update, so that we avoid downloading mid session.
 	// Do not `await` here. Let this happen in the background.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { DebugProtocol } from '@vscode/debugprotocol';
 import { ConfigurationProvider, pendingAttaches } from './debugger';
 import { MirrordStatus } from './status';
 import { getMirrordBinary } from './binaryManager';
@@ -36,59 +37,62 @@ export async function activate(context: vscode.ExtensionContext) {
 				let attachPromise: Promise<boolean> | null = null;
 
 				return {
-					// This is untyped for now.
-					onDidSendMessage: async (message: any) => {
+					onDidSendMessage: async (message: DebugProtocol.ProtocolMessage) => {
 						/* ────────────────────────────────────────────────────────────────────────── */
 
 						// This code heavily depends on the DAP specification, please refer to
 						// https://microsoft.github.io/debug-adapter-protocol//specification.html
-						// if you are confused about any usage in the untyped code.
+						// if you are confused about any usage here.
 
 						/* ────────────────────────────────────────────────────────────────────────── */
 
 						// DAP 'process' event carries `systemProcessId`.
 						// This fires once when the debug adapter spawns the target process.
 						// We inject the mirrord layer DLL into it here.
-						if (message.type === 'event' && message.event === 'process') {
-							const pid = message.body?.systemProcessId;
-							if (pid && !attachPromise) {
-								Logger.info(`mirrord: attaching to process ${pid}`);
-								attachPromise = (async () => {
-									try {
-										const api = new MirrordAPI(pending.cliPath);
-										await api.attach(pid, pending.configEnv);
-										Logger.info(`mirrord: layer injected into process ${pid}`);
-										return true;
-									} catch (err) {
-										const errorMsg = err instanceof Error ? err.message : String(err);
-										Logger.error(`mirrord: attach failed: ${errorMsg}`);
-										vscode.window.showErrorMessage(`mirrord attach failed: ${errorMsg}`);
-										return false;
-									}
-								})();
+						if (message.type === 'event') {
+							const event = message as DebugProtocol.Event;
+							if (event.event === 'process') {
+								const processEvent = event as DebugProtocol.ProcessEvent;
+								const pid = processEvent.body?.systemProcessId;
+								if (pid && !attachPromise) {
+									Logger.info(`mirrord: attaching to process ${pid}`);
+									attachPromise = (async () => {
+										try {
+											const api = new MirrordAPI(pending.cliPath);
+											await api.attach(pid, pending.configEnv);
+											Logger.info(`mirrord: layer injected into process ${pid}`);
+											return true;
+										} catch (err) {
+											const errorMsg = err instanceof Error ? err.message : String(err);
+											Logger.error(`mirrord: attach failed: ${errorMsg}`);
+											vscode.window.showErrorMessage(`mirrord attach failed: ${errorMsg}`);
+											return false;
+										}
+									})();
+								}
 							}
-						}
 
-						// DAP 'stopped' event with reason 'entry' fires when the debugger
-						// pauses at entry due to stopOnEntry/stopAtEntry we set.
-						// This arrives in a later `onDidSendMessage` call than 'process'.
-						// We await the closure's `attachPromise` to ensure DLL injection
-						// finished, then resume if the user didn't originally request
-						// stop-on-entry.
-						if (!pending.userHadStopOnEntry
-							&& message.type === 'event' && message.event === 'stopped'
-							&& message.body?.reason === 'entry'
-							&& attachPromise) {
-							const success = await attachPromise;
-							if (success) {
-								const threadId = message.body?.threadId;
-								if (threadId !== undefined) {
-									Logger.info(`mirrord: resuming after forced stop-on-entry`);
-									try {
-										await session.customRequest('continue', { threadId });
-									} catch (err) {
-										const errorMsg = err instanceof Error ? err.message : String(err);
-										Logger.error(`mirrord: failed to resume: ${errorMsg}`);
+							// DAP 'stopped' event with reason 'entry' fires when the debugger
+							// pauses at entry due to stopOnEntry/stopAtEntry we set.
+							// This arrives in a later `onDidSendMessage` call than 'process'.
+							// We await the closure's `attachPromise` to ensure DLL injection
+							// finished, then resume if the user didn't originally request
+							// stop-on-entry.
+							if (!pending.userHadStopOnEntry && event.event === 'stopped' && attachPromise) {
+								const stoppedEvent = event as DebugProtocol.StoppedEvent;
+								if (stoppedEvent.body?.reason === 'entry') {
+									const success = await attachPromise;
+									if (success) {
+										const threadId = stoppedEvent.body?.threadId;
+										if (threadId !== undefined) {
+											Logger.info(`mirrord: resuming after forced stop-on-entry`);
+											try {
+												await session.customRequest('continue', { threadId });
+											} catch (err) {
+												const errorMsg = err instanceof Error ? err.message : String(err);
+												Logger.error(`mirrord: failed to resume: ${errorMsg}`);
+											}
+										}
 									}
 								}
 							}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { DebugProtocol } from '@vscode/debugprotocol';
-import { ConfigurationProvider, pendingAttaches } from './debugger';
+import { ConfigurationProvider, PendingAttach, pendingAttaches } from './debugger';
 import { MirrordStatus } from './status';
 import { getMirrordBinary } from './binaryManager';
 import { MirrordAPI } from './api';
@@ -22,19 +22,45 @@ export async function activate(context: vscode.ExtensionContext) {
 	// On Windows, register a DAP tracker to catch the process start event
 	// and inject the mirrord layer via `mirrord attach <PID>`.
 	if (process.platform === "win32") {
+		Logger.info("Registering DAP tracker factory for Windows attach flow");
 		vscode.debug.registerDebugAdapterTrackerFactory('*', {
 			createDebugAdapterTracker(session: vscode.DebugSession) {
 				if (pendingAttaches.length === 0) {
 					return undefined;
 				}
 
-				const pending = pendingAttaches.shift()!;
+				Logger.debug(`Creating DAP tracker for session "${session.name}" (type=${session.type}), ${pendingAttaches.length} pending attach(es)`);
 
-				// Closure variable shared across `onDidSendMessage` invocations for
-				// this debug session. Set once when we receive the DAP 'process' event,
-				// then awaited by the 'stopped' handler to ensure DLL injection is
-				// complete before resuming execution.
+				// These are set when we consume a pending attach — either from
+				// a DAP 'process' event (which carries systemProcessId) or from
+				// a 'stopped' event with reason 'entry' (for debuggers like
+				// pwa-node that don't emit 'process' on child sessions).
+				let pending: PendingAttach | null = null;
 				let attachPromise: Promise<boolean> | null = null;
+
+				/**
+				 * Consume a pending attach and start DLL injection for the given PID.
+				 */
+				function startAttach(pid: number): void {
+					if (pending || pendingAttaches.length === 0) {
+						return;
+					}
+					pending = pendingAttaches.shift()!;
+					Logger.info(`mirrord: attaching to process ${pid}`);
+					attachPromise = (async () => {
+						try {
+							const api = new MirrordAPI(pending!.cliPath);
+							await api.attach(pid, pending!.configEnv);
+							Logger.info(`mirrord: layer injected into process ${pid}`);
+							return true;
+						} catch (err) {
+							const errorMsg = err instanceof Error ? err.message : String(err);
+							Logger.error(`mirrord: attach failed: ${errorMsg}`);
+							vscode.window.showErrorMessage(`mirrord attach failed: ${errorMsg}`);
+							return false;
+						}
+					})();
+				}
 
 				return {
 					onDidSendMessage: async (message: DebugProtocol.ProtocolMessage) => {
@@ -46,55 +72,105 @@ export async function activate(context: vscode.ExtensionContext) {
 
 						/* ────────────────────────────────────────────────────────────────────────── */
 
+						if (message.type !== 'event') {
+							return;
+						}
+
+						const event = message as DebugProtocol.Event;
+
 						// DAP 'process' event carries `systemProcessId`.
 						// This fires once when the debug adapter spawns the target process.
-						// We inject the mirrord layer DLL into it here.
-						if (message.type === 'event') {
-							const event = message as DebugProtocol.Event;
-							if (event.event === 'process') {
-								const processEvent = event as DebugProtocol.ProcessEvent;
-								const pid = processEvent.body?.systemProcessId;
-								if (pid && !attachPromise) {
-									Logger.info(`mirrord: attaching to process ${pid}`);
-									attachPromise = (async () => {
-										try {
-											const api = new MirrordAPI(pending.cliPath);
-											await api.attach(pid, pending.configEnv);
-											Logger.info(`mirrord: layer injected into process ${pid}`);
-											return true;
-										} catch (err) {
-											const errorMsg = err instanceof Error ? err.message : String(err);
-											Logger.error(`mirrord: attach failed: ${errorMsg}`);
-											vscode.window.showErrorMessage(`mirrord attach failed: ${errorMsg}`);
-											return false;
-										}
-									})();
+						// We shift from pendingAttaches here (not in createDebugAdapterTracker)
+						// because pwa-node spawns a parent session first, then a child session
+						// for the actual process — and only the child gets the 'process' event.
+						if (event.event === 'process') {
+							const processEvent = event as DebugProtocol.ProcessEvent;
+							const pid = processEvent.body?.systemProcessId;
+
+							if (!pid) {
+								Logger.warn(`DAP process event for "${session.name}" has no systemProcessId`);
+								return;
+							}
+
+							if (pending) {
+								Logger.debug(`Ignoring process event for "${session.name}" (pid=${pid}), pending attach already consumed`);
+								return;
+							}
+
+							if (pendingAttaches.length === 0) {
+								Logger.debug(`Process event for "${session.name}" (pid=${pid}) but no pending attaches in queue`);
+								return;
+							}
+
+							startAttach(pid);
+						}
+
+						// DAP 'stopped' event with reason 'entry' fires when the debugger
+						// pauses at entry due to stopOnEntry/stopAtEntry we set.
+						//
+						// Some debuggers (e.g. pwa-node) do NOT emit a 'process' event on the
+						// child session, so 'stopped' with reason 'entry' is the first signal
+						// that the process is alive and paused. In that case we extract the PID
+						// from the session name (pattern: "name [PID]" or "name [PID] « parent").
+						//
+						// If the 'process' event already fired, `pending` and `attachPromise`
+						// are set, so we just await and resume.
+						if (event.event === 'stopped') {
+							const stoppedEvent = event as DebugProtocol.StoppedEvent;
+
+							if (stoppedEvent.body?.reason !== 'entry') {
+								return;
+							}
+
+							Logger.debug(`Stopped-on-entry event for "${session.name}"`);
+
+							// If no 'process' event was received, try to consume a pending
+							// attach now, extracting the PID from the session name.
+							if (!pending && pendingAttaches.length > 0) {
+								const pidMatch = session.name.match(/\[(\d+)\]/);
+								if (pidMatch) {
+									const pid = parseInt(pidMatch[1]!, 10);
+									Logger.debug(`Extracted pid=${pid} from session name "${session.name}"`);
+									startAttach(pid);
+								} else {
+									Logger.warn(`Could not extract PID from session name "${session.name}" — no [PID] pattern found`);
 								}
 							}
 
-							// DAP 'stopped' event with reason 'entry' fires when the debugger
-							// pauses at entry due to stopOnEntry/stopAtEntry we set.
-							// This arrives in a later `onDidSendMessage` call than 'process'.
-							// We await the closure's `attachPromise` to ensure DLL injection
-							// finished, then resume if the user didn't originally request
-							// stop-on-entry.
-							if (!pending.userHadStopOnEntry && event.event === 'stopped' && attachPromise) {
-								const stoppedEvent = event as DebugProtocol.StoppedEvent;
-								if (stoppedEvent.body?.reason === 'entry') {
-									const success = await attachPromise;
-									if (success) {
-										const threadId = stoppedEvent.body?.threadId;
-										if (threadId !== undefined) {
-											Logger.info(`mirrord: resuming after forced stop-on-entry`);
-											try {
-												await session.customRequest('continue', { threadId });
-											} catch (err) {
-												const errorMsg = err instanceof Error ? err.message : String(err);
-												Logger.error(`mirrord: failed to resume: ${errorMsg}`);
-											}
-										}
-									}
-								}
+							if (!pending) {
+								Logger.debug(`No pending attach consumed for "${session.name}", skipping resume`);
+								return;
+							}
+
+							if (pending.userHadStopOnEntry) {
+								Logger.debug(`User had stop-on-entry enabled, not auto-resuming "${session.name}"`);
+								return;
+							}
+
+							if (!attachPromise) {
+								Logger.warn(`No attach promise for "${session.name}", cannot resume`);
+								return;
+							}
+
+							const success = await attachPromise;
+							if (!success) {
+								Logger.warn(`Attach was not successful for "${session.name}", not resuming`);
+								return;
+							}
+
+							const threadId = stoppedEvent.body?.threadId;
+							if (threadId === undefined) {
+								Logger.warn(`No threadId in stopped event for "${session.name}", cannot resume`);
+								return;
+							}
+
+							Logger.info(`mirrord: resuming after forced stop-on-entry`);
+							try {
+								await session.customRequest('continue', { threadId });
+								Logger.debug(`Resumed thread ${threadId} for "${session.name}"`);
+							} catch (err) {
+								const errorMsg = err instanceof Error ? err.message : String(err);
+								Logger.error(`mirrord: failed to resume: ${errorMsg}`);
 							}
 						}
 					},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -164,7 +164,7 @@ export async function activate(context: vscode.ExtensionContext) {
 								return;
 							}
 
-							Logger.info(`mirrord: resuming after forced stop-on-entry`);
+							Logger.debug(`mirrord: resuming after forced stop-on-entry`);
 							try {
 								await session.customRequest('continue', { threadId });
 								Logger.debug(`Resumed thread ${threadId} for "${session.name}"`);

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 import { MirrordConfigManager } from './config';
 import { globalContext } from './extension';
-import { NotificationBuilder } from './notification';
 import { getOperatorUsed } from './mirrordForTeams';
 import { NEWSLETTER_COUNTER } from './api';
 
@@ -92,13 +91,6 @@ export class MirrordStatus {
     }
 
     toggle() {
-        if (process.platform === "win32") {
-            new NotificationBuilder()
-                .withMessage("mirrord is not supported on Windows. You can use it via remote development or WSL.")
-                .error();
-            return;
-        }
-
         this.enabled = !this.enabled;
 
         this.draw();

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,8 +1,18 @@
 import * as vscode from 'vscode';
+import * as semver from 'semver';
 import { MirrordConfigManager } from './config';
 import { globalContext } from './extension';
 import { getOperatorUsed } from './mirrordForTeams';
-import { NEWSLETTER_COUNTER } from './api';
+import { NEWSLETTER_COUNTER, MirrordAPI } from './api';
+import { NotificationBuilder } from './notification';
+import { getMirrordBinary } from './binaryManager';
+
+/**
+ * Returns true if the extension host is running in a remote session (WSL, SSH, Dev Container, etc.).
+ */
+function isRemoteSession(): boolean {
+    return !!vscode.env.remoteName;
+}
 
 export class MirrordStatus {
     readonly statusBar: vscode.StatusBarItem;
@@ -59,6 +69,12 @@ export class MirrordStatus {
     }
 
     register(): MirrordStatus {
+        // Check the mirrord version for support every single time the
+        // extension is loaded.
+        if (process.platform === "win32") {
+            this.checkWindowsSupport();
+        }
+
         const configManager = MirrordConfigManager.getInstance();
         globalContext.subscriptions.push(configManager);
 
@@ -93,6 +109,14 @@ export class MirrordStatus {
     toggle() {
         this.enabled = !this.enabled;
 
+        // Check the mirrord version for support every single time the extension
+        // is toggled on.
+        if (this.enabled) {
+            if (process.platform === "win32") {
+                this.checkWindowsSupport();
+            }
+        }
+
         this.draw();
     }
 
@@ -111,5 +135,44 @@ export class MirrordStatus {
 
     documentation() {
         vscode.env.openExternal(vscode.Uri.parse('https://mirrord.dev/docs/using-mirrord/vscode-extension/?utm_medium=vscode&utm_source=ui_action'));
+    }
+
+    /**
+     * Checks whether the installed mirrord binary supports Windows.
+     * Windows support requires mirrord version 3.201.0 or above.
+     *
+     * Skips the check when running in a remote session (WSL, SSH, Dev Container)
+     * since mirrord runs on the remote host, not locally.
+     *
+     * @returns `true` if the version is supported (or cannot be determined), `false` otherwise.
+     */
+    private async checkWindowsSupport(): Promise<boolean> {
+        // If it's a remote (including WSL), we don't need to check
+        // locally for mirrord.exe.
+        if (isRemoteSession()) {
+            return true;
+        }
+
+        try {
+            const binaryPath = await getMirrordBinary(true);
+            // Just in case, return true if we can't get the binary path yet.
+            if (!binaryPath) {
+                return true;
+            }
+
+            const api = new MirrordAPI(binaryPath);
+            const version = await api.getBinaryVersion();
+            if (version && semver.lt(version, '3.201.0')) {
+                new NotificationBuilder()
+                    .withMessage(`mirrord ${version} is not supported on Windows. Windows support requires mirrord version 3.201.0 or above.`)
+                    .error();
+                return false;
+            }
+            
+            return true;
+        } catch {
+            // If we can't determine the version, don't block the user.
+            return true;
+        }
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,6 @@ const config = {
             }]
         }]
     },
-}
+};
 
 module.exports = config;


### PR DESCRIPTION
TL;DR:
<img width="2100" height="2512" alt="tldr" src="https://github.com/user-attachments/assets/f0cc8eda-9c13-437c-ae11-7b8e7d1a01e6" />


This implementation of Windows support for the IDE extension is dependant on getting the PR https://github.com/metalbear-co/mirrord/pull/3995 merged first.

Afterwards, a version check should be introduced to ensure that existing users update to the latest version before attempting to use the IDE extension, as it depends on the completely new `mirrord.exe attach` command, and now supported `mirrord.exe ext` command.

Paraphrasing of the overview, rationale, etc, will be copied here over from the CLI/layer PR.

---

## Overview

This is a PR that implements IDE extension support using the aforementioned `mirrord.exe attach` command. You may refer to it to gain a basic understanding of the concept.

## The core issue

Unix supports the `LD_PRELOAD` (or the MacOS equivalent, for dylibs, and whatnot) environment variable as a way to tell processes to load a dynamic library.

Windows, unfortunately, does not have any such similar mechanism. That means that we cannot facillitate the loading of the mirrord layer through environment variables as the Unix versions of the code do, in the case of IDE extensions.

## The suggested solution

The suggested equivalent is invoking the `attach` command, **being used with `stopOnEntry` (and friends for respective languages) to substitute the now-optional signal event**, making sure that no relevant user code runs before layer is initialized, and then running `attach` upon a **Process Event** ([as defined by the DAP](https://microsoft.github.io/debug-adapter-protocol//specification.html)) with the provided `systemProcessId`.

This will always point to the user-code process, so this does not require explicit handling. Moreover, this process will always have an appropriate environment for the layer to initialize because `intproxy` was already set up, and `mirrord.exe ext` was used to generate the relevant environment variables.

## Notes

`mirrord.exe attach` is:
1. Windows-only (the technique *could* be ported over to Unix, but manual mapping on there is it's own ordeal);
2. Marked as hidden to the CLI, as it should never be manually invoked;

## Responsibilities

1. We ensure that every process we `attach` to has an appropriate environment;
2. We ensure that every process we `attach` to is paused, and has the layer load, before user code can run.

