### PR TITLE
feat: surface CLI upgrade links as Sign up for Teams button

### DIFF
--- a/changelog.d/+ide-upgrade-links.added.md
+++ b/changelog.d/+ide-upgrade-links.added.md
@@ -1,0 +1,1 @@
+When the mirrord CLI exits with an upgrade-related error, VS Code now shows a "Sign up for Teams" button that links directly to app.metalbear.com.

--- a/src/api.ts
+++ b/src/api.ts
@@ -271,6 +271,8 @@ export class MirrordAPI {
       "MIRRORD_PROGRESS_MODE": "json",
       // to have "advanced" progress in IDE
       "MIRRORD_PROGRESS_SUPPORT_IDE": "true",
+      // so the CLI generates vscode-specific UTM links directly
+      "MIRRORD_IDE_NAME": "vscode",
       // to have namespaces in the `mirrord ls` output
       "MIRRORD_LS_RICH_OUTPUT": "true"
     };

--- a/src/api.ts
+++ b/src/api.ts
@@ -500,6 +500,10 @@ export class MirrordAPI {
               notification.withGenericAction("Sign up for Teams", async () => {
                 vscode.env.openExternal(vscode.Uri.parse(upgradeUrl));
               });
+            } else if (error["help"]) {
+              notification.withGenericAction("Help", async () => {
+                vscode.window.showInformationMessage(error["help"]);
+              });
             }
             notification.error();
             return reject(error["message"]);

--- a/src/api.ts
+++ b/src/api.ts
@@ -324,6 +324,10 @@ export class MirrordAPI {
             notification.withGenericAction("Sign up for Teams", async () => {
               vscode.env.openExternal(vscode.Uri.parse(upgradeUrl));
             });
+          } else if (error["help"]) {
+            notification.withGenericAction("Help", async () => {
+              vscode.window.showInformationMessage(error["help"]);
+            });
           }
           notification.error();
           return reject(error["message"]);

--- a/src/api.ts
+++ b/src/api.ts
@@ -271,8 +271,6 @@ export class MirrordAPI {
       "MIRRORD_PROGRESS_MODE": "json",
       // to have "advanced" progress in IDE
       "MIRRORD_PROGRESS_SUPPORT_IDE": "true",
-      // so the CLI generates vscode-specific UTM links directly
-      "MIRRORD_IDE_NAME": "vscode",
       // to have namespaces in the `mirrord ls` output
       "MIRRORD_LS_RICH_OUTPUT": "true"
     };

--- a/src/api.ts
+++ b/src/api.ts
@@ -271,6 +271,8 @@ export class MirrordAPI {
       "MIRRORD_PROGRESS_MODE": "json",
       // to have "advanced" progress in IDE
       "MIRRORD_PROGRESS_SUPPORT_IDE": "true",
+      // so the CLI generates vscode-specific UTM links directly
+      "MIRRORD_IDE_NAME": "vscode",
       // to have namespaces in the `mirrord ls` output
       "MIRRORD_LS_RICH_OUTPUT": "true"
     };
@@ -317,9 +319,10 @@ export class MirrordAPI {
           const error = JSON.parse(match);
           const notification = new NotificationBuilder()
             .withMessage(`mirrord error: ${error["message"]}`);
-          if (error["help"]) {
-            notification.withGenericAction("Help", async () => {
-              vscode.window.showInformationMessage(error["help"]);
+          const upgradeUrl = `${error["message"] ?? ""} ${error["help"] ?? ""}`.match(/https:\/\/app\.metalbear\.com\/[^\s]*/)?.[0];
+          if (upgradeUrl) {
+            notification.withGenericAction("Sign up for Teams", async () => {
+              vscode.env.openExternal(vscode.Uri.parse(upgradeUrl));
             });
           }
           notification.error();
@@ -488,9 +491,10 @@ export class MirrordAPI {
             const error = JSON.parse(match);
             const notification = new NotificationBuilder()
               .withMessage(`mirrord error: ${error["message"]}`);
-            if (error["help"]) {
-              notification.withGenericAction("Help", async () => {
-                vscode.window.showInformationMessage(error["help"]);
+            const upgradeUrl = `${error["message"] ?? ""} ${error["help"] ?? ""}`.match(/https:\/\/app\.metalbear\.com\/[^\s]*/)?.[0];
+            if (upgradeUrl) {
+              notification.withGenericAction("Sign up for Teams", async () => {
+                vscode.env.openExternal(vscode.Uri.parse(upgradeUrl));
               });
             }
             notification.error();


### PR DESCRIPTION
## Summary
- Sets `MIRRORD_IDE_NAME=vscode` when spawning the CLI so it generates vscode-specific UTM links directly
- When the CLI exits with an error, checks both `message` and `help` fields for an `app.metalbear.com` URL
- If found, shows a **"Sign up for Teams"** button instead of a plain help popup

## Why both fields?
Some errors put the URL in `message` (e.g. `OperatorLicenseExpired`), others in `help` (e.g. `FeatureRequiresOperatorError`). Checking both ensures we catch all upgrade paths.

## Test plan
- [ ] Create `.mirrord/mirrord.json` with `{"operator": true}`, run a debug session against a local cluster without the operator -- verify "Sign up for Teams" button appears
- [ ] Verify the button URL has `utm_medium=vscode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)