### PR TITLE
fix: windows autoupdate

### DIFF
--- a/changelog.d/+windows-autoupdate.fixed.md
+++ b/changelog.d/+windows-autoupdate.fixed.md
@@ -1,0 +1,1 @@
+Fixed auto-update to support Windows.

--- a/src/binaryManager.ts
+++ b/src/binaryManager.ts
@@ -16,7 +16,9 @@ const mirrordBinaryEndpoint = 'https://version.mirrord.dev/v1/version';
 const baseDownloadUri = 'https://github.com/metalbear-co/mirrord/releases/download';
 
 function getExtensionMirrordPath(): Uri {
-    return Utils.joinPath(globalContext.globalStorageUri, 'mirrord');
+    // NOTE: windows does not support running executables without an extension.
+    const binaryName = process.platform === 'win32' ? 'mirrord.exe' : 'mirrord';
+    return Utils.joinPath(globalContext.globalStorageUri, binaryName);
 }
 
 
@@ -41,7 +43,7 @@ export async function getLocalMirrordBinary(version: string | null): Promise<[st
         } else {
             return [mirrordPath, true];
         }
-    } catch (e) {  
+    } catch (e) {
         const errorMsg = e instanceof Error ? e.message : String(e);
         Logger.warn(`couldn't find mirrord in path: ${errorMsg}`);
     }
@@ -235,7 +237,32 @@ function getMirrordDownloadUrl(version: string): string {
             default:
                 break;
         }
+    } else if (process.platform === "win32") {
+        switch (process.arch) {
+            case 'x64':
+                return `${baseDownloadUri}/${version}/mirrord.exe`;
+
+            case `arm64`:
+                throw new Error(
+                    `mirrord does not currently provide a Windows ${process.arch} build. `
+                    + `If you require ${process.arch} support, please open an issue at `
+                    + `https://github.com/metalbear-co/mirrord/issues so we can gauge interest.`
+                );
+
+            // Windows is one of the cursed places where you still find people using, god forbid, 32-bit.
+            case 'ia32':
+            case 'arm':
+                // https://github.com/torvalds/linux/blob/master/include/math-emu/double.h#L29
+                throw new Error(
+                    `Here's a nickel kid. Go buy yourself a real computer `
+                    + `(${process.platform} ${process.arch} not supported).`
+                );
+
+            default:
+                break;
+        }
     }
+
     throw new Error(`Unsupported platform ${process.platform} ${process.arch}`);
 }
 

--- a/src/binaryManager.ts
+++ b/src/binaryManager.ts
@@ -238,28 +238,8 @@ function getMirrordDownloadUrl(version: string): string {
                 break;
         }
     } else if (process.platform === "win32") {
-        switch (process.arch) {
-            case 'x64':
-                return `${baseDownloadUri}/${version}/mirrord.exe`;
-
-            case `arm64`:
-                throw new Error(
-                    `mirrord does not currently provide a Windows ${process.arch} build. `
-                    + `If you require ${process.arch} support, please open an issue at `
-                    + `https://github.com/metalbear-co/mirrord/issues so we can gauge interest.`
-                );
-
-            // Windows is one of the cursed places where you still find people using, god forbid, 32-bit.
-            case 'ia32':
-            case 'arm':
-                // https://github.com/torvalds/linux/blob/master/include/math-emu/double.h#L29
-                throw new Error(
-                    `Here's a nickel kid. Go buy yourself a real computer `
-                    + `(${process.platform} ${process.arch} not supported).`
-                );
-
-            default:
-                break;
+        if (process.arch === 'x64') {
+            return `${baseDownloadUri}/${version}/mirrord.exe`;
         }
     }
 

--- a/src/status.ts
+++ b/src/status.ts
@@ -161,12 +161,23 @@ export class MirrordStatus {
             return true;
         }
 
+        if (process.arch === 'ia32' || process.arch === 'arm') {
+            // Windows is one of the cursed places where you still find people using, god forbid, 32-bit.
+            new NotificationBuilder()
+                .withMessage(
+                    `Here's a nickel kid. Go buy yourself a real computer `
+                    + `(${process.platform} ${process.arch} not supported).`
+                )
+                .error();
+            return false;
+        }
+
         if (process.arch !== 'x64') {
             new NotificationBuilder()
                 .withMessage(
                     `mirrord does not currently provide a Windows ${process.arch} build. `
-                    + `If you require ${process.arch} support, please open an issue at `
-                    + `https://github.com/metalbear-co/mirrord/issues so we can gauge interest.`
+                    + `If you require ${process.arch} support, please upvote or comment on `
+                    + `https://github.com/metalbear-co/mirrord/issues/4162 so we can gauge interest.`
                 )
                 .error();
             return false;

--- a/src/status.ts
+++ b/src/status.ts
@@ -138,19 +138,38 @@ export class MirrordStatus {
     }
 
     /**
-     * Checks whether the installed mirrord binary supports Windows.
-     * Windows support requires mirrord version 3.201.0 or above.
+     * Checks whether the current host can run mirrord on Windows.
+     *
+     * Verifies two things, in order:
+     * 1. The host architecture is supported — mirrord currently only ships a
+     *    Windows x64 build, so any other `process.arch` is rejected with a
+     *    notification pointing users at the issue tracker.
+     * 2. The installed mirrord binary is recent enough — Windows support
+     *    requires mirrord version 3.201.0 or above.
      *
      * Skips the check when running in a remote session (WSL, SSH, Dev Container)
      * since mirrord runs on the remote host, not locally.
      *
-     * @returns `true` if the version is supported (or cannot be determined), `false` otherwise.
+     * @returns `true` if the host is supported and the version is compatible
+     * (or cannot be determined), `false` if the arch is unsupported or the
+     * installed binary is too old.
      */
     private async checkWindowsSupport(): Promise<boolean> {
         // If it's a remote (including WSL), we don't need to check
         // locally for mirrord.exe.
         if (isRemoteSession()) {
             return true;
+        }
+
+        if (process.arch !== 'x64') {
+            new NotificationBuilder()
+                .withMessage(
+                    `mirrord does not currently provide a Windows ${process.arch} build. `
+                    + `If you require ${process.arch} support, please open an issue at `
+                    + `https://github.com/metalbear-co/mirrord/issues so we can gauge interest.`
+                )
+                .error();
+            return false;
         }
 
         try {


### PR DESCRIPTION
tested by manually specifying `"mirrord.autoUpdate": "<version>"`