### PR TITLE
chore(prompts): refresh nudge messages and canonical domain

### DIFF
--- a/changelog.d/+refresh-prompts-and-canonical-domain.changed.md
+++ b/changelog.d/+refresh-prompts-and-canonical-domain.changed.md
@@ -1,0 +1,1 @@
+Refreshed the mirrord-for-Teams notification copy, dropped the earliest newsletter prompt threshold, and switched all URLs to the `metalbear.com` canonical domain.

--- a/src/api.ts
+++ b/src/api.ts
@@ -37,9 +37,8 @@ export const NEWSLETTER_COUNTER = 'mirrord-newsletter-counter';
 /**
 * Amount of times we run mirrord before inviting the user to sign up to the newsletter.
 */
-const NEWSLETTER_COUNTER_PROMPT_AFTER_FIRST = 5;
-const NEWSLETTER_COUNTER_PROMPT_AFTER_SECOND = 20;
-const NEWSLETTER_COUNTER_PROMPT_AFTER_THIRD = 100;
+const NEWSLETTER_COUNTER_PROMPT_AFTER_FIRST = 20;
+const NEWSLETTER_COUNTER_PROMPT_AFTER_SECOND = 100;
 
 /**
 * Environment variable name for listing targets with a specific type via the CLI 'ls' command.
@@ -190,13 +189,13 @@ export function mirrordFailure(error: string) {
   new NotificationBuilder()
     .withMessage(`${error}. Please check the logs/errors.`)
     .withGenericAction("Get help on Slack", async () => {
-      vscode.env.openExternal(vscode.Uri.parse('https://metalbear.co/slack'));
+      vscode.env.openExternal(vscode.Uri.parse('https://metalbear.com/slack'));
     })
     .withGenericAction("Open an issue on GitHub", async () => {
       vscode.env.openExternal(vscode.Uri.parse('https://github.com/metalbear-co/mirrord/issues/new/choose'));
     })
     .withGenericAction("Send us an email", async () => {
-      vscode.env.openExternal(vscode.Uri.parse('mailto:hi@metalbear.co'));
+      vscode.env.openExternal(vscode.Uri.parse('mailto:hi@metalbear.com'));
     })
     .error();
 }
@@ -677,12 +676,9 @@ function tickNewsletterCounter() {
   let msg;
   switch (currentRuns) {
     case NEWSLETTER_COUNTER_PROMPT_AFTER_FIRST:
-      msg = "Join thousands of devs using mirrord!\nGet the latest updates, tutorials, and insider info from our team.";
-      break;
-    case NEWSLETTER_COUNTER_PROMPT_AFTER_SECOND:
       msg = "Liking what mirrord can do?\nStay in the loop with updates, tips & tricks straight from the team.";
       break;
-    case NEWSLETTER_COUNTER_PROMPT_AFTER_THIRD:
+    case NEWSLETTER_COUNTER_PROMPT_AFTER_SECOND:
       msg = "Looks like you're doing some serious work with mirrord!\nWant to hear about advanced features, upcoming releases, and cool use cases?";
       break;
     default:

--- a/src/mirrordForTeams.ts
+++ b/src/mirrordForTeams.ts
@@ -26,7 +26,7 @@ export function tickMirrordForTeamsCounter() {
   if (counter >= NOTIFICATION_STARTS_AT) {
     if (((counter - NOTIFICATION_STARTS_AT) % NOTIFICATION_REPEATS_EVERY === 0) && !operatorUsed) {
       showMirrordForTeamsNotification(
-        'For more features of mirrord, including multi-pod impersonation, check out mirrord for Teams.'
+        'mirrord for Teams unlocks team workflow features: DB branching for parallel devs, preview environments for branch testing, and shared targets with queue splitting.'
       );
     }
   }

--- a/src/status.ts
+++ b/src/status.ts
@@ -121,16 +121,16 @@ export class MirrordStatus {
     }
 
     joinSlack() {
-        vscode.env.openExternal(vscode.Uri.parse('https://metalbear.co/slack'));
+        vscode.env.openExternal(vscode.Uri.parse('https://metalbear.com/slack'));
     }
 
     mirrordForTeams() {
-        vscode.env.openExternal(vscode.Uri.parse('https://app.metalbear.co/?utm_medium=vscode&utm_source=ui_action'));
+        vscode.env.openExternal(vscode.Uri.parse('https://app.metalbear.com/?utm_medium=vscode&utm_source=ui_action'));
     }
 
     newsletter() {
         const count = globalContext.globalState.get(NEWSLETTER_COUNTER);
-        vscode.env.openExternal(vscode.Uri.parse("https://metalbear.co/newsletter" + "?utm_medium=vscode&utm_source=newsletter" + count));
+        vscode.env.openExternal(vscode.Uri.parse("https://metalbear.com/newsletter" + "?utm_medium=vscode&utm_source=newsletter" + count));
     }
 
     documentation() {


### PR DESCRIPTION
## Summary

Refreshes the mirrord-for-Teams notification copy (now names DB branching, preview environments, and shared targets with queue splitting instead of leading with "multi-pod impersonation"), drops the earliest newsletter prompt threshold, and switches all `metalbear.co` URLs to `metalbear.com` for consistency with the CLI.

## Coordinated PRs

Same product surface across the three plugins:
- CLI: metalbear-co/mirrord#4257
- IntelliJ: metalbear-co/mirrord-intellij#435
- VSCode: this PR

## Test plan
- [ ] CI passes
- [ ] mirrord-for-Teams notification at run 100 (when not using operator) shows the new copy
- [ ] Newsletter prompt fires at 20 and 100 runs, not 5
- [ ] All Slack/app/email links go to `metalbear.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)