### PR TITLE
docs(readme): rewrite intro and align all links to metalbear.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # mirrord for Visual Studio Code
 
-[![Community Slack](https://img.shields.io/badge/Join-e5f7f7?logo=slack&label=Community%20Slack)](https://metalbear.co/slack)
+[![Community Slack](https://img.shields.io/badge/Join-e5f7f7?logo=slack&label=Community%20Slack)](https://metalbear.com/slack)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/metalbear-co/mirrord-vscode)
-[![Twitter Follow](https://img.shields.io/twitter/follow/metalbearco?style=social)](https://x.com/metalbear)
+[![Twitter Follow](https://img.shields.io/twitter/follow/metalbear?style=social)](https://x.com/metalbear)
 [![VSCode Marketplace](https://img.shields.io/badge/VSCode%20Extension%20Page-756df3)](https://marketplace.visualstudio.com/items?itemName=MetalBear.mirrord)
 
-mirrord lets developers [run local processes in the context of their cloud environment](https://mirrord.dev). It provides the benefits of running your service on a cloud environment (e.g. staging) without going through the hassle of deploying it there, and without disrupting the environment by deploying untested code. It comes as a Visual Studio Code extension, an IntelliJ plugin and a CLI tool. You can read more about what mirrord does [in our official docs](https://mirrord.dev/docs/overview/introduction/), or [sign up to our newsletter](https://metalbear.co/newsletter) to hear about new features.
+mirrord lets developers and AI coding agents [run local processes inside a live Kubernetes cluster](https://metalbear.com/mirrord). Your code stays on your machine, but mirrord routes its traffic, files, and environment through a target pod in the cluster. Use it to read live cluster context while writing code (real env vars, real service responses, real queue contents), and to run the code against those same services and data once it's written. You get the feedback of a deploy in seconds, without the deploy, and without disrupting the cluster for anyone else.
+
+This extension brings that workflow to VS Code. mirrord also ships as a JetBrains plugin and a CLI tool. Read more in [the docs](https://metalbear.com/mirrord/docs/overview/introduction/), or [sign up to our newsletter](https://metalbear.com/newsletter) to hear about new features.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/metalbear-co/mirrord-vscode/main/media/readme/demo_gif_cropped.gif" width="90%" alt="A gif showing mirrord being used to steal traffic from a kubernetes cluster in the VSCode UI">
@@ -33,13 +35,13 @@ mirrord's main repository can be found [here](https://github.com/metalbear-co/mi
 
 * The debugged process will start with mirrord, and receive the context of the impersonated pod. It will receive its environment variables and incoming traffic, will read and write files to it, and send outgoing traffic through it.
 
-> Unless explicitly set [in the config](https://mirrord.dev/docs/reference/configuration/#root-kubeconfig), mirrord uses your machine's default kubeconfig for access to the Kubernetes API. Alternatively, use the [port mapping configuration](https://mirrord.dev/docs/reference/configuration/#feature-network-incoming-port_mapping).
+> Unless explicitly set [in the config](https://metalbear.com/mirrord/docs/reference/configuration/#root-kubeconfig), mirrord uses your machine's default kubeconfig for access to the Kubernetes API. Alternatively, use the [port mapping configuration](https://metalbear.com/mirrord/docs/reference/configuration/#feature-network-incoming-port_mapping).
 
 > For incoming traffic, make sure your local process is listening on the same port as the remote pod.
 
 ## Configuring mirrord for VSCode
 
-mirrord allows for rich configuration of the environment it provides. The schema for it is documented [here](https://mirrord.dev/docs/reference/configuration/). The extension supports autocomplete for `json` files, but you can also use `toml` or `yaml` format.
+mirrord allows for rich configuration of the environment it provides. The schema for it is documented [here](https://metalbear.com/mirrord/docs/reference/configuration/). The extension supports autocomplete for `json` files, but you can also use `toml` or `yaml` format.
 
 _Quick start: the easiest way to start configuring mirrord is to choose_ "Settings" _from the status bar menu, which will open a new `mirrord.json`._
 
@@ -57,11 +59,11 @@ all logs emitted by the extension.
 
 ## Helpful Links
 
-* [Official documentation for this extension](https://mirrord.dev/docs/using-mirrord/vscode-extension/)
-* [Official language-specific guides for debugging](https://metalbear.co/guides/)
+* [Official documentation for this extension](https://metalbear.com/mirrord/docs/using-mirrord/vscode-extension/)
+* [Official language-specific guides for debugging](https://metalbear.com/mirrord/docs/guides)
 
 ## Contributions, feature requests, issues and support
 
-* Feel free to join to our [Slack](https://metalbear.co/slack) if you need help using mirrord, or if you encounter an issue while using the extension.
+* Feel free to join to our [Slack](https://metalbear.com/slack) if you need help using mirrord, or if you encounter an issue while using the extension.
 * Check our open issues for [the VSCode extension](https://github.com/metalbear-co/mirrord-vscode/issues) and [mirrord's core code](https://github.com/metalbear-co/mirrord/issues), and 👍 react to any that you would like to see addressed.
 * Before submitting a pull request for new features, please take a look at [mirrord's contributing guide](https://github.com/metalbear-co/mirrord/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Community Slack](https://img.shields.io/badge/Join-e5f7f7?logo=slack&label=Community%20Slack)](https://metalbear.com/slack)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/metalbear-co/mirrord-vscode)
-[![Twitter Follow](https://img.shields.io/twitter/follow/metalbear?style=social)](https://x.com/metalbear)
+[![X Follow](https://img.shields.io/twitter/follow/metalbear?style=social)](https://x.com/metalbear)
 [![VSCode Marketplace](https://img.shields.io/badge/VSCode%20Extension%20Page-756df3)](https://marketplace.visualstudio.com/items?itemName=MetalBear.mirrord)
 
 mirrord lets developers and AI coding agents [run local processes inside a live Kubernetes cluster](https://metalbear.com/mirrord). Your code stays on your machine, but mirrord routes its traffic, files, and environment through a target pod in the cluster. Use it to read live cluster context while writing code (real env vars, real service responses, real queue contents), and to run the code against those same services and data once it's written. You get the feedback of a deploy in seconds, without the deploy, and without disrupting the cluster for anyone else.

--- a/changelog.d/+readme-agent-thesis.internal.md
+++ b/changelog.d/+readme-agent-thesis.internal.md
@@ -1,0 +1,1 @@
+Rewrote the README intro to name both audiences (developers and AI coding agents) and aligned all `metalbear.co`/`mirrord.dev` links to the `metalbear.com` canonical domain.


### PR DESCRIPTION
## Summary
Brings this README in line with the metalbear-co/mirrord README rewrite (metalbear-co/mirrord#4272):

1. **Replaces wishy-washy phrasing.** "It provides the benefits of... without going through the hassle of..." becomes a direct statement of what mirrord does and what the user gets.
2. **Names both audiences explicitly.** Developer in an IDE + AI coding agent.
3. **Surfaces both halves of the loop.** Read live cluster context while writing code (real env vars, real service responses, real queue contents), then run the code against those same services and data once it's written.
4. **Aligns all links to `metalbear.com`.** `metalbear.co` website links and `mirrord.dev` links both point to the canonical domain (`metalbear.com` and `metalbear.com/mirrord` respectively). `metalbear-co` GitHub org slugs are untouched.

## Why
The VS Code marketplace listing mirrors this README and is one of the first surfaces a technical evaluator hits. The post-agent thesis is well-developed on /mirrord/ai but underweighted on the surfaces a build-vs-buy reviewer actually walks through first.

## Test plan
- [ ] GitHub renders the README correctly (no broken markdown)
- [ ] All `metalbear.com` and `metalbear.com/mirrord` links resolve
- [ ] No `metalbear-co/` GitHub org slugs were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)