### PR TITLE
[bot] Pass workspace git branch to verify-config and ls

### DIFF
--- a/changelog.d/+verify-config-branch-name.fixed.md
+++ b/changelog.d/+verify-config-branch-name.fixed.md
@@ -1,0 +1,1 @@
+Pass the workspace's git branch (`MIRRORD_BRANCH_NAME`) to `mirrord verify-config` and `mirrord ls`, so configs using the `git_branch` template variable no longer fail with "Variable `git_branch` not found in context".

--- a/src/api.ts
+++ b/src/api.ts
@@ -378,13 +378,38 @@ export class MirrordAPI {
   }
 
   /**
+  * Returns `configEnv` extended with `MIRRORD_BRANCH_NAME` set to the workspace's current git
+  * branch. The CLI resolves the `git_branch` config template variable from its own working
+  * directory, but processes spawned by the extension inherit the extension host's working
+  * directory rather than the user's project, so the branch has to be passed explicitly.
+  */
+  private async envWithBranchName(configEnv: EnvVars, workspacePath: string | undefined): Promise<EnvVars> {
+    if (workspacePath === undefined) {
+      return configEnv;
+    }
+
+    const branchName = await this.getBranchName(workspacePath)
+      .catch(error => {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        Logger.debug(`cannot retrieve git branch name ${errorMsg}`);
+      })
+      .then((res) => res ? res.trim() : "");
+
+    if (branchName.length === 0) {
+      return configEnv;
+    }
+
+    return { MIRRORD_BRANCH_NAME: branchName, ...configEnv };
+  }
+
+  /**
   * Uses `mirrord ls` to get lists of targets and namespaces.
-  * 
+  *
   * Note that old CLI versions return only targets.
-  * 
+  *
   * @see MirrordLsOutput
   */
-  async listTargets(configPath: string | null | undefined, configEnv: EnvVars, targetTypes: string[], namespace?: string,): Promise<MirrordLsOutput> {
+  async listTargets(configPath: string | null | undefined, configEnv: EnvVars, targetTypes: string[], workspacePath: string | undefined, namespace?: string,): Promise<MirrordLsOutput> {
     const args = ['ls'];
     if (configPath) {
       args.push('-f', configPath);
@@ -396,7 +421,7 @@ export class MirrordAPI {
 
     configEnv[MIRRORD_LS_TARGET_TYPES_ENV] = JSON.stringify(targetTypes);
 
-    const stdout = await this.exec(args, configEnv);
+    const stdout = await this.exec(args, await this.envWithBranchName(configEnv, workspacePath));
 
     const targets = JSON.parse(stdout) as MirrordLsOutput | string[];
     let mirrordLsOutput: MirrordLsOutput;
@@ -417,7 +442,7 @@ export class MirrordAPI {
   * Executes the `mirrord verify-config {configPath}` command, parsing its output into a
   * `VerifiedConfig`.
   */
-  async verifyConfig(configPath: vscode.Uri | null, configEnv: EnvVars): Promise<VerifiedConfig | undefined> {
+  async verifyConfig(configPath: vscode.Uri | null, configEnv: EnvVars, workspacePath: string | undefined): Promise<VerifiedConfig | undefined> {
     if (configPath) {
       // NOTE: `fsPath`/`_fsPath` is correct, whereas `path` is incorrect,
       // for cross-platform support. e.g.:
@@ -427,7 +452,7 @@ export class MirrordAPI {
       //
       // See the documentation for more information.
       const args = ['verify-config', '--ide', `${configPath.fsPath}`];
-      const stdout = await this.exec(args, configEnv);
+      const stdout = await this.exec(args, await this.envWithBranchName(configEnv, workspacePath));
 
       const verifiedConfig: VerifiedConfig = JSON.parse(stdout);
       return verifiedConfig;
@@ -460,15 +485,7 @@ export class MirrordAPI {
     tickSlackCounter();
     tickNewsletterCounter();
 
-    let branchName = "";
-    if (workspacePath !== undefined) {
-      branchName = await this.getBranchName(workspacePath)
-        .catch(error => {
-          const errorMsg = error instanceof Error ? error.message : String(error);
-          Logger.debug(`cannot retrieve git branch name ${errorMsg}`);
-        })
-        .then((res) => res ? res.trim() : "");
-    }
+    const envWithBranch = await this.envWithBranchName(configEnv, workspacePath);
 
     /// Create a promise that resolves when the mirrord process exits
     return await vscode.window.withProgress({
@@ -484,12 +501,9 @@ export class MirrordAPI {
         const args = makeMirrordArgs(quickPickSelection?.path, configFile, executable);
         let env: EnvVars;
         if (quickPickSelection?.namespace) {
-          env = { MIRRORD_TARGET_NAMESPACE: quickPickSelection.namespace, ...configEnv };
+          env = { MIRRORD_TARGET_NAMESPACE: quickPickSelection.namespace, ...envWithBranch };
         } else {
-          env = configEnv;
-        }
-        if (branchName.length > 0) {
-          env = { MIRRORD_BRANCH_NAME: branchName, ...env };
+          env = envWithBranch;
         }
 
         const child = this.spawnCliWithArgsAndEnv(args, env);

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -168,7 +168,11 @@ async function main(
       folder,
       config,
     );
-  const verifiedConfig = await mirrordApi.verifyConfig(configPath, config.env);
+  const verifiedConfig = await mirrordApi.verifyConfig(
+    configPath,
+    config.env,
+    folder?.uri.fsPath,
+  );
 
   // If target wasn't specified in the config file (or there's no config file), let user choose pod from dropdown
   if (!configPath || (verifiedConfig && !isTargetSet(verifiedConfig))) {
@@ -178,6 +182,7 @@ async function main(
         configPath?.fsPath,
         config.env,
         supportedTypes,
+        folder?.uri.fsPath,
         namespace,
       );
     };


### PR DESCRIPTION
> [!WARNING]
> Opened by the MetalBear Slack support bot — generated by Claude, not reviewed or run by a human. Adopt before merging. Source thread: https://metalbear.slack.com/archives/C0BNCQY3FGV/p1787056933725429

## Summary
- Configs using `{{ git_branch }}` failed in the extension with `Variable git_branch not found in context` while the same config worked in the CLI.
- Cause: the extension spawns the CLI with the extension host's cwd, so `git branch --show-current` resolves nothing. `binaryExecute` already compensated by passing `MIRRORD_BRANCH_NAME`, but `verify-config` runs first and `mirrord ls` also renders the config — neither got it, so verification failed before execution started.
- Fix: shared `envWithBranchName` helper in `MirrordAPI`; `verifyConfig`, `listTargets` and `binaryExecute` all pass `MIRRORD_BRANCH_NAME` resolved from the workspace folder (same override the JetBrains plugin uses).

## Tests
- Ran locally: `npm run test-compile` (tsc), `npm run lint` — clean.
- e2e suite not run (needs a VSCode install + cluster; not available in the bot container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)