### PR TITLE
Fix CI e2e failure and auto release PR job

### DIFF
--- a/.github/workflows/auto-release-pr.yaml
+++ b/.github/workflows/auto-release-pr.yaml
@@ -139,7 +139,11 @@ jobs:
           git commit -m "Prepare release ${{ steps.bump.outputs.new_version }}"
           # Use an app token so PR opened/synchronize events trigger CI normally.
           git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push --force-with-lease --set-upstream origin "${branch}"
+
+          remote_sha=$(git ls-remote origin "refs/heads/${branch}" | cut -f1)
+          git push \
+            --force-with-lease="refs/heads/${branch}:${remote_sha}" \
+            --set-upstream origin "${branch}"
 
           existing_pr_url=$(
             gh pr list \

--- a/.github/workflows/reusable_e2e.yaml
+++ b/.github/workflows/reusable_e2e.yaml
@@ -94,32 +94,60 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
+      - name: use the locally built agent image
+        if: ${{ inputs.mirrord_release_branch }}
+        run: echo "MIRRORD_AGENT_IMAGE=test" >> "$GITHUB_ENV"
+
       # we can't run chrome like apps in the CI, we use a virtual frame buffer:
       # refer: http://elementalselenium.com/tips/38-headless
       - name: Run vscode e2e in headless state
-        if: ${{ inputs.mirrord_release_branch }}
         env:
           POD_TO_SELECT: ${{ env.POD_TO_SELECT }}
           KUBE_SERVICE: ${{ env.KUBE_SERVICE }}
-          MIRRORD_AGENT_IMAGE: "test"
         run: |
           sudo apt-get update
           sudo apt-get install -y xvfb x11-xserver-utils ffmpeg
-          /usr/bin/xvfb-run -s ":99 -auth /tmp/xvfb.auth -ac -screen 0 1920x1080x24" npm run test &
-          ffmpeg -loglevel panic -y -framerate 30 -f x11grab -video_size 1920x1080 -i :99 out.webm
-          wait -n
 
-      - name: Run vscode e2e in headless state
-        if: ${{ !inputs.mirrord_release_branch }}
-        env:
-          POD_TO_SELECT: ${{ env.POD_TO_SELECT }}
-          KUBE_SERVICE: ${{ env.KUBE_SERVICE }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y xvfb x11-xserver-utils ffmpeg
           /usr/bin/xvfb-run -s ":99 -auth /tmp/xvfb.auth -ac -screen 0 1920x1080x24" npm run test &
-          ffmpeg -loglevel panic -y -framerate 30 -f x11grab -video_size 1920x1080 -i :99 out.webm
-          wait -n
+          test_pid=$!
+
+          display_up=false
+          for _ in $(seq 1 60); do
+            if xset -display :99 q > /dev/null 2>&1; then
+              display_up=true
+              break
+            fi
+            # Nothing left to record for if the tests already died with the display.
+            if ! kill -0 "${test_pid}" 2> /dev/null; then
+              break
+            fi
+            sleep 0.5
+          done
+
+          ffmpeg_pid=
+          if [ "${display_up}" = "true" ]; then
+            ffmpeg -loglevel error -y -framerate 30 -f x11grab -video_size 1920x1080 -i :99 out.webm &
+            ffmpeg_pid=$!
+          else
+            echo "::warning::display :99 never came up, running the tests without a recording"
+          fi
+
+          test_exit=0
+          wait "${test_pid}" || test_exit=$?
+
+          if [ -n "${ffmpeg_pid}" ]; then
+            # SIGINT so ffmpeg writes the trailer instead of leaving an unplayable file behind,
+            # but never let a stuck recorder hold the job open.
+            kill -INT "${ffmpeg_pid}" 2> /dev/null || true
+            for _ in $(seq 1 20); do
+              kill -0 "${ffmpeg_pid}" 2> /dev/null || break
+              sleep 0.5
+            done
+            kill -KILL "${ffmpeg_pid}" 2> /dev/null || true
+            wait "${ffmpeg_pid}" 2> /dev/null || true
+          fi
+
+          exit "${test_exit}"
 
       # the video starts at around ~2 minutes, before that you will see a black screen
       - name: Upload video

--- a/changelog.d/+ci-e2e-and-auto-release-pr.internal.md
+++ b/changelog.d/+ci-e2e-and-auto-release-pr.internal.md
@@ -1,0 +1,1 @@
+Fix CI e2e test failure and auto release PR job failure when the branch already exists.


### PR DESCRIPTION
## Fix two recurring CI failures

### 1. e2e job failed with `exit code 251`

The step started `npm run test` and `ffmpeg` at the same moment. `xvfb-run` waits for Xvfb before launching the tests, but `ffmpeg` had no such gate — when it won the race it exited 251 (`Cannot open display`), and as the step's foreground command under `bash -e` that killed the job while the tests were still compiling.

Now the step waits for `:99` to answer before starting `ffmpeg`, runs the recording in the background, and exits with the tests' exit code. `ffmpeg` gets SIGINT at the end so `out.webm` is finalized and actually uploads. The two copies of the script are merged into one step so they can't drift apart.

### 2. Auto Release PR failed with `stale info`

`git push --force-with-lease` with no explicit expectation needs a remote-tracking ref, but `actions/checkout` makes a single-branch clone of `main`, so `releases/*` never has one. The push therefore failed whenever the release branch already existed.

Now the workflow reads the current remote tip with `git ls-remote` and leases against it explicitly. Updating an existing release branch works, creating a new one works, and a concurrent push is still rejected.