### PR TITLE
Wait for Xvfb before starting the e2e screen recorder

### DIFF
--- a/.github/workflows/reusable_e2e.yaml
+++ b/.github/workflows/reusable_e2e.yaml
@@ -106,7 +106,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y xvfb x11-xserver-utils ffmpeg
           /usr/bin/xvfb-run -s ":99 -auth /tmp/xvfb.auth -ac -screen 0 1920x1080x24" npm run test &
-          ffmpeg -loglevel panic -y -framerate 30 -f x11grab -video_size 1920x1080 -i :99 out.webm
+          # xvfb-run is backgrounded, so display :99 does not exist yet when this line is
+          # reached. ffmpeg exits 251 (AVERROR(EIO)) if it attaches before the display is
+          # up, which under `bash -e` aborts the step before a single test has run.
+          for _ in $(seq 30); do
+            xdpyinfo -display :99 >/dev/null 2>&1 && break
+            sleep 1
+          done
+          # The recording is diagnostic only, so it must never decide the job's outcome.
+          ffmpeg -loglevel error -y -framerate 30 -f x11grab -video_size 1920x1080 -i :99 out.webm || true
           wait -n
 
       - name: Run vscode e2e in headless state
@@ -118,7 +126,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y xvfb x11-xserver-utils ffmpeg
           /usr/bin/xvfb-run -s ":99 -auth /tmp/xvfb.auth -ac -screen 0 1920x1080x24" npm run test &
-          ffmpeg -loglevel panic -y -framerate 30 -f x11grab -video_size 1920x1080 -i :99 out.webm
+          # xvfb-run is backgrounded, so display :99 does not exist yet when this line is
+          # reached. ffmpeg exits 251 (AVERROR(EIO)) if it attaches before the display is
+          # up, which under `bash -e` aborts the step before a single test has run.
+          for _ in $(seq 30); do
+            xdpyinfo -display :99 >/dev/null 2>&1 && break
+            sleep 1
+          done
+          # The recording is diagnostic only, so it must never decide the job's outcome.
+          ffmpeg -loglevel error -y -framerate 30 -f x11grab -video_size 1920x1080 -i :99 out.webm || true
           wait -n
 
       # the video starts at around ~2 minutes, before that you will see a black screen

--- a/changelog.d/+xvfb-race-e2e-recording.internal.md
+++ b/changelog.d/+xvfb-race-e2e-recording.internal.md
@@ -1,0 +1,1 @@
+Wait for the Xvfb display before starting the e2e screen recorder, and stop a failed recording from failing the job.


### PR DESCRIPTION
The vscode e2e job has been failing with `Process completed with exit code 251` without any test output. That code is `AVERROR(EIO)` from ffmpeg: `xvfb-run` is backgrounded, so display `:99` often isn't up yet when ffmpeg attaches. ffmpeg runs in the foreground under `bash -e`, so it aborted the whole step before a single test ran, and `-loglevel panic` suppressed the reason — which made it look like the preceding `npm run lint` was at fault.

Confirmed on three consecutive runs: no `out.webm` artifact, and post-job cleanup terminating `npm run test`/`npm run lint` as orphans, i.e. the test process was still alive when the step died.

Fix polls `xdpyinfo` (already installed via `x11-xserver-utils`) for up to 30s, drops `-loglevel panic` so the next failure is diagnosable, and appends `|| true` so a recording problem can't fail the tests. Applied to both the release-branch and non-release variants.

Tested: YAML and shell bodies parse (`bash -n`); the real check is this PR's own CI, which exercises the non-release path.

https://claude.ai/code/session_01GjgTsZaTrf184V9LJKasvm